### PR TITLE
Update downloading datasets

### DIFF
--- a/src/capymoa/datasets/__init__.py
+++ b/src/capymoa/datasets/__init__.py
@@ -1,0 +1,19 @@
+from .datasets import (
+    CovtFD,
+    Covtype,
+    RBFm_100k,
+    RTG_2abrupt,
+    Hyper100k,
+    Sensor,
+    ElectricityTiny,
+)
+
+__all__ = [
+    "Hyper100k",
+    "CovtFD",
+    "Covtype",
+    "RBFm_100k",
+    "RTG_2abrupt",
+    "Sensor",
+    "ElectricityTiny",
+]

--- a/src/capymoa/datasets/datasets.py
+++ b/src/capymoa/datasets/datasets.py
@@ -1,0 +1,52 @@
+from capymoa.datasets.downloader import DownloadARFFGzip
+
+ROOT_URL = "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/standardised/"
+
+
+class Sensor(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "sensor.arff"
+    remote_url = ROOT_URL
+
+
+class Hyper100k(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "Hyper100k.arff"
+    remote_url = ROOT_URL
+
+
+class CovtFD(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "covtFD.arff"
+    remote_url = ROOT_URL
+
+
+class Covtype(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "covtype.arff"
+    remote_url = ROOT_URL
+
+
+class RBFm_100k(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "RBFm_100k.arff"
+    remote_url = ROOT_URL
+
+
+class RTG_2abrupt(DownloadARFFGzip):
+    # TODO: Add docstring describing the dataset and link to the original source
+
+    filename = "RTG_2abrupt.arff"
+    remote_url = ROOT_URL
+
+
+class ElectricityTiny(DownloadARFFGzip):
+    """A tiny version of the Electricity dataset."""
+
+    filename = "electricity_tiny.arff"
+    remote_url = ROOT_URL

--- a/src/capymoa/datasets/downloader.py
+++ b/src/capymoa/datasets/downloader.py
@@ -1,0 +1,113 @@
+import gzip
+import shutil
+from abc import ABC, abstractmethod
+from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Optional
+
+import wget
+from moa.streams import ArffFileStream
+
+from capymoa.stream.stream import Stream
+
+CAPYMOA_DATASETS_DIR = environ.get("CAPYMOA_DATASETS_DIR", "data")
+"""A default directory to store datasets in. Defaults to `./data` when the
+environment variable `CAPYMOA_DATASETS_DIR` is not set.
+"""
+
+
+class DownloadableDataset(ABC, Stream):
+    filename: str = None
+    """Name of the dataset in the capymoa dataset directory"""
+
+    def __init__(
+        self,
+        directory: str = CAPYMOA_DATASETS_DIR,
+        auto_download: bool = True,
+        CLI: Optional[str] = None,
+        schema: Optional[str] = None,
+    ):
+        assert self.filename is not None, "Filename must be set in subclass"
+        stream = self._resolve_dataset(
+            auto_download,
+            Path(directory).resolve(),
+        )
+        moa_stream = self.to_stream(stream)
+        super().__init__(schema=schema, CLI=CLI, moa_stream=moa_stream)
+
+    def _resolve_dataset(self, auto_download: bool, directory: Path):
+        stream = directory / self.filename
+
+        if not stream.exists():
+            if auto_download:
+                with TemporaryDirectory() as working_directory:
+                    working_directory = Path(working_directory)
+                    stream_archive = self.download(working_directory)
+                    tmp_stream = self.extract(stream_archive)
+                    stream = tmp_stream.rename(stream)
+            else:
+                raise FileNotFoundError(
+                    f"Dataset {self.filename} not found in {directory}"
+                )
+
+        return stream
+
+    @abstractmethod
+    def download(self, working_directory: Path) -> Path:
+        """Download the dataset and return the path to the downloaded dataset
+        within the working directory.
+
+        :param working_directory: The directory to download the dataset to.
+        :return: The path to the downloaded dataset within the working directory.
+        """
+        pass
+
+    @abstractmethod
+    def extract(self, stream_archive: Path) -> Path:
+        """Extract the dataset from the archive and return the path to the
+        extracted dataset.
+
+        :param stream_archive: The path to the archive containing the dataset.
+        :return: The path to the extracted dataset.
+        """
+        pass
+
+    @abstractmethod
+    def to_stream(self, stream: Path):
+        """Convert the dataset to a MOA stream.
+
+        :param stream: The path to the dataset.
+        :return: A MOA stream.
+        """
+        pass
+
+
+class DownloadARFFGzip(DownloadableDataset):
+    filename = None
+    remote_url = None
+
+    def download(self, working_directory: Path) -> Path:
+        assert self.remote_url is not None, "Remote URL must be set in subclass"
+
+        print(f"Downloading {self.filename}")
+
+        archive_filename = self.filename + ".gz"
+        save_path = working_directory / archive_filename
+        remote_path = self.remote_url + archive_filename
+        path = wget.download(remote_path, save_path.as_posix())
+        return Path(path)
+
+    def extract(self, stream_archive: Path) -> Path:
+        # Remove the .gz extension
+        assert stream_archive.suffix == ".gz"
+        stream: Path = stream_archive.with_suffix("")
+
+        # Extract the archive
+        with gzip.open(stream_archive, "rb") as f_in:
+            with open(stream, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        return stream
+
+    def to_stream(self, stream: Path) -> Any:
+        return ArffFileStream(stream.as_posix(), -1)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,28 @@
+from capymoa.datasets import *
+from tempfile import TemporaryDirectory
+import pytest
+import numpy as np
+
+
+def test_electricity_tiny():
+    with TemporaryDirectory() as tmp_dir:
+        # Ensure that the dataset is not downloaded
+        with pytest.raises(FileNotFoundError):
+            stream = ElectricityTiny(directory=tmp_dir, auto_download=False)
+
+        stream = ElectricityTiny(directory=tmp_dir)
+        first_instance: np.ndarray = stream.next_instance().x()
+
+        assert first_instance == pytest.approx(
+            np.array([0, 0.056443, 0.439155, 0.003467, 0.422915, 0.414912])
+        )
+
+        # This should still work because the dataset is downloaded
+        stream = ElectricityTiny(directory=tmp_dir, auto_download=False)
+
+
+@pytest.mark.skip(reason="Too slow for CI")
+def test_all_datasets():
+    for dataset in [Hyper100k, CovtFD, Covtype, RBFm_100k, RTG_2abrupt]:
+        with TemporaryDirectory() as tmp_dir:
+            stream = dataset(directory=tmp_dir)


### PR DESCRIPTION
This pull request is a draft of how downloading datasets could work. Currently, it only works with one dataset, `Hyper100k`. I intend to add the others once I get feedback.

The dataset can be used like this:
```python
from capymoa.datasets import Hyper100k
stream = Hyper100k()
```
If a dataset does not exist, capymoa will download it. The default dataset location is `./data` unless the user sets an environment variable (`CAPYMOA_DATASETS_DIR`).

The user can override both defaults using:
```python
from capymoa.datasets import Hyper100k
stream = Hyper100k(directory=my_dir)
```

The only file format supported at the moment is a gzip compressed arff.