### PR TITLE
Create capymoa package

### DIFF
--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+# TODO: In the future we ought to perform linting and code coverage checks
+
+name: Python package tests
+
+on:
+  push:
+    # TODO: Remove package
+    branches: [ "main", "package" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install '.[dev]'
+    - name: Test with pytest
+      run: |
+        pytest

--- a/README.md
+++ b/README.md
@@ -1,23 +1,36 @@
 # CapyMOA
 Python wrapper for MOA to allow efficient use of existing algorithms with a more modern API
 
-To use the project
-1. Use ```conda env create -f environment.yml``` to create a conda environment with all the requirements. 
-	* Optional: Use pip install on the requirements. 
-	* If you are using a custom installation, make sure to install jpype through ```pip install jpype1``` (yes, there is a 1 there)
- 	* If you are using windows, use ```environment_wds.yml``` instead of ```environment.yml```
-2. Run ```make download``` to get the MOA jar.
-   	* Optional: In ```config.ini``` set the path to the ```moa.jar``` that you are using if you are using a custom ```moa.jar```, otherwise the jar specified in [```src/capymoa/jar/accessing_jar.txt```](src/capymoa/jar/accessing_jar.txt)) will be used. It should work with any MOA jar released after 2023, but some functions may not work (as they haven't been merged into moa yet, such as the SSL supporting functions). 
-3. Make sure `JAVA_HOME` is set. 
-4. Activate the conda environment ```conda activate CapyMOA```
-5. Add the project to your python path in your ```.bashrc```, 
-   ```.bash_profile```, ```.zshrc``` or ```.profile``` with the following command (replace ```<MY PATH HERE>``` with the path to the project):
-```sh
-export PYTHONPATH=$PYTHONPATH:<MY PATH HERE>/CapyMOA/src
-```
-6. Try the DEMO notebook ```jupyter notebook DEMO.ipynb```. The notebook must be
-   started with the correct ```PYTHONPATH``` and ```JAVA_HOME``` variables set.
-   To double check run ```echo $PYTHONPATH``` and ```echo $JAVA_HOME``` in the
+
+# Developer Installation
+
+1. **(Optional)** It is recommended to use a conda environment since using a
+   conda environment isolates project dependencies and avoids conflicts.
+   > Follow the instructions [at this link](https://docs.conda.io/projects/miniconda/en/latest/) to install miniconda.
+
+   Setup the conda environment by running one of the following commands:
+   ```sh
+   conda env create -f environment.yml # For linux
+   conda env create -f environment_wds.yml # For windows
+   ```
+   Ensure the environment is activated:
+   ```sh
+   conda activate CapyMOA
+   ```
+2. Use pip to install the project in editable mode with the development dependencies:
+   ```bash
+   pip install --editable '.[dev]'
+   ```
+3. Make sure the environment variable `JAVA_HOME` is set.
+4. Run the tests to make sure everything is working:
+   ```bash
+   python -m pytest
+   ```
+5. **(Optional)** Try the example notebooks
+   1. Download extra datasets with `make download`.
+   2. Run the DEMO notebook ```python -m jupyter notebook notebooks/DEMO.ipynb```. The notebook must be
+   started with the correct ```JAVA_HOME``` variable set.
+   To double check run ```echo $JAVA_HOME``` in the
    terminal before starting the notebook.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+# wget is used to download the MOA jar file
+requires = ["hatchling", "hatch-build-scripts", "wget"]
+# Build system: https://hatch.pypa.io
+# The main reason I chose hatch is its support for plugins allowing us to
+# download the MOA jar file before the build starts.
+build-backend = "hatchling.build"
+
+[project]
+name = "capymoa"
+version = "0.0.1"
+description = "Python wrapper for MOA to allow efficient use of existing algorithms with a more modern API."
+requires-python = ">=3.8"
+# Defines the pip packages that are required by this package. These should be
+# as permissive as possible, since capymoa should collaborate with other
+# packages.
+dependencies = [
+    "jpype1",
+    "wget",
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "river",
+]
+
+[project.optional-dependencies]
+dev=[
+    "pytest",
+    "jupyter"
+]
+
+[tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
+
+[tool.hatch]
+[tool.hatch.build.targets.wheel]
+# Defines the directories included in the wheel package
+packages = ["src/capymoa"]
+artifacts = ["src/capymoa/jar/moa.jar"]
+
+[tool.hatch.build.targets.sdist]
+# Defines the directories included in the source distribution package (sdist).
+packages = ["src/capymoa"]
+artifacts = ["src/capymoa/jar/moa.jar"]
+
+[[tool.hatch.build.hooks.build-scripts.scripts]]
+# Ensures that the MOA jar file is downloaded before the build starts.
+commands = [
+    "python scripts/download_moa.py",
+]
+artifacts = []
+

--- a/scripts/download_datasets_and_moa.py
+++ b/scripts/download_datasets_and_moa.py
@@ -6,30 +6,30 @@ import shutil
 from pathlib import Path
 
 z_files = {
-#    "covtFD": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/covtFD.zip",
-#        "zip",
-#    ],
-#    "covtype": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/covtype.zip",
-#        "zip",
-#    ],
-#    "Hyper100k": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/Hyper100k.zip",
-#        "zip",
-#    ],
-#    "RBFm_100k": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/RBFm_100k.zip",
-#        "zip",
-#    ],
-#    "RTG_2abrupt": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/RTG_2abrupt.zip",
-#        "zip",
-#    ],
-#    "sensor": [
-#        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/sensor.zip",
-#        "zip",
-#    ],
+    "covtFD": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/covtFD.zip",
+        "zip",
+    ],
+    "covtype": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/covtype.zip",
+        "zip",
+    ],
+    "Hyper100k": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/Hyper100k.zip",
+        "zip",
+    ],
+    "RBFm_100k": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/RBFm_100k.zip",
+        "zip",
+    ],
+    "RTG_2abrupt": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/RTG_2abrupt.zip",
+        "zip",
+    ],
+    "sensor": [
+        "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/sensor.zip",
+        "zip",
+    ],
     "moa": [
         "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/moa.jar",
         "jar",

--- a/scripts/download_moa.py
+++ b/scripts/download_moa.py
@@ -1,0 +1,11 @@
+import wget
+from pathlib import Path
+
+if __name__ == "__main__":
+    moa_path = Path("src/capymoa/jar/moa.jar")
+    if not moa_path.exists():
+        url = "https://homepages.ecs.vuw.ac.nz/~antonlee/capymoa/moa.jar"
+        print(f"Downloading moa.jar from : {url}")
+        wget.download(url, out=moa_path.resolve().as_posix())
+    else:
+        print(f"moa.jar already exists at {moa_path}")


### PR DESCRIPTION
- Installing CapyMOA for development is as easy as (although using the `envrionment.yml` is recommended):
  ```
  conda create -n CapyMOA python==3.10
  conda activate CapyMOA
  pip install --editable '.[dev]'
  python -m pytest
  ```
- No longer need `PYTHONPATH` set.
- Added a workflow to install and run tests with github actions using python 3.9, 3.10, and 3.11.
- Automatically downloads and packages the moa jar while building the package.
- Uses hatch as the build system https://hatch.pypa.io.
- Line `.github/workflows/python-package-test.yml:10` is used to run actions during development and will be removed once this is merged.

![image](https://github.com/hmgomes/CapyMOA/assets/37557393/731f07be-117c-4b6a-9667-a880f5e9ecbe)

