### PR TITLE
Fix benchmarking

### DIFF
--- a/notebooks/benchmarking.py
+++ b/notebooks/benchmarking.py
@@ -88,10 +88,10 @@ def run_MOA_experiment(
             sample_frequency=MAX_INSTANCES,
         )
         print(
-            f"{arff_path}, {model.__str__()} {CLI}, {results['cumulative'].accuracy():.4f}, {results['wallclock']:.4f}, {results['cpu_time']:.4f}"
+            f"{arff_path}, \"{model.__str__()} {CLI}\", {results['cumulative'].accuracy():.4f}, {results['wallclock']:.4f}, {results['cpu_time']:.4f}"
         )
         writer.writerow(
-            [arff_path, model.__str__() + CLI, results['cumulative'].accuracy(), results['wallclock'], results['cpu_time']]
+            [arff_path, '"'+model.__str__() + CLI+'"', results['cumulative'].accuracy(), results['wallclock'], results['cpu_time']]
         )
 
 
@@ -110,10 +110,10 @@ def run_RIVER_experiment(
             sample_frequency=MAX_INSTANCES,
         )
         print(
-            f"{csv_path}, {model.__class__.__name__} {CLI}, {acc:.4f}, {wallclock:.4f}, {cpu_time:.4f}"
+            f'{csv_path}, "{model.__class__.__name__} {CLI}", {acc:.4f}, {wallclock:.4f}, {cpu_time:.4f}'
         )
         writer.writerow(
-            [csv_path, model.__class__.__name__ + CLI, acc, wallclock, cpu_time]
+            [csv_path, '"'+model.__class__.__name__ + CLI+'"', acc, wallclock, cpu_time]
         )
 
 


### PR DESCRIPTION
## Test:
run  ```python notebooks/benchmarking.py``` from **source root.**

```
(CapyMOA) ng98@MacBook-Pro-2 CapyMOA_Latest % python notebooks/benchmarking.py
capymoa_root: /Users/ng98/Desktop/CODE/CapyMOA_Latest/src/capymoa
MOA jar path location (config.ini): /Users/ng98/Desktop/CODE/CapyMOA_Latest/src/capymoa/jar/moa.jar
JVM Location (system): 
JAVA_HOME: /Users/ng98/Library/Java/JavaVirtualMachines/openjdk-14.0.1/Contents/Home
JVM args: ['-Xmx8g', '-Xss10M']
Sucessfully started the JVM and added MOA jar to the class path
./data/RTG_2abrupt.arff, NaiveBayes , 89.0000, 0.0341, 0.0987
./data/RTG_2abrupt.arff, HoeffdingTree , 89.0000, 0.1926, 0.4802
./data/RTG_2abrupt.arff, EFDT , 89.0000, 0.0388, 0.1062
./data/RTG_2abrupt.arff, kNN  -w 1000 -k 3, 89.0000, 0.0383, 0.0953
./data/RTG_2abrupt.arff, AdaptiveRandomForest -s 5 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.1573, 0.4187
./data/RTG_2abrupt.arff, AdaptiveRandomForest -s 10 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.1788, 0.4813
./data/RTG_2abrupt.arff, AdaptiveRandomForest -s 30 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.2989, 0.7495
./data/RTG_2abrupt.arff, AdaptiveRandomForest -s 100 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.9259, 2.4048
./data/RTG_2abrupt.arff, AdaptiveRandomForest -s 100 -j 4 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.4406, 1.9487
./data/RTG_2abrupt.arff, StreamingRandomPatches -s 5 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.0633, 0.1498
./data/RTG_2abrupt.arff, StreamingRandomPatches -s 10 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.1578, 0.3716
./data/RTG_2abrupt.arff, StreamingRandomPatches -s 30 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.2598, 0.6211
./data/RTG_2abrupt.arff, StreamingRandomPatches -s 100 -o (Percentage (M * (m / 100))) -m 60, 90.0000, 0.8409, 2.2152
./data/RTG_2abrupt.csv, GaussianNB , 0.8800, 0.1011, 0.1333
./data/RTG_2abrupt.csv, HoeffdingTreeClassifier , 0.8900, 0.0322, 0.0322
./data/RTG_2abrupt.csv, KNNClassifier engine=LazySearch(window_size=1000), n_neighbors=3, 0.8800, 0.0909, 0.0908
./data/RTG_2abrupt.csv, ARFClassifier n_models=5,max_features=0.60, 0.8600, 0.3265, 0.3267
./data/RTG_2abrupt.csv, ARFClassifier n_models=10,max_features=0.60, 0.8700, 0.5901, 0.5903
./data/RTG_2abrupt.csv, ARFClassifier n_models=30,max_features=0.60, 0.8800, 1.7797, 1.7798
./data/RTG_2abrupt.csv, ARFClassifier n_models=100,max_features=0.60, 0.8900, 6.1324, 6.1302
./data/RTG_2abrupt.csv, SRPClassifier n_models=5,subspace_size=0.60, 0.8700, 0.7667, 0.7668
./data/RTG_2abrupt.csv, SRPClassifier n_models=10,subspace_size=0.60, 0.8700, 1.5661, 1.5610
./data/RTG_2abrupt.csv, SRPClassifier n_models=30,subspace_size=0.60, 0.8800, 4.3760, 4.3709
./data/RTG_2abrupt.csv, SRPClassifier n_models=100,subspace_size=0.60, 0.8800, 14.7937, 14.7863

```