### PR TITLE
build: remove river from default dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,8 @@ docs/notebooks
 
 src/moa-stubs
 src/com-stubs
+
+# Nixos files
+shell.nix
+.envrc
+.direnv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,9 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
-    "river",
     "matplotlib",
     "scikit-learn",
     "click",
-    "python-semantic-release~=9.5.0"
 ]
 
 [project.optional-dependencies]
@@ -56,6 +54,7 @@ doc=[
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 pythonpath = ["src"]
+testpaths = ["tests", "src"]
 norecursedirs = [
     "docs/*"
 ]


### PR DESCRIPTION
- "python-semantic-release~=9.5.0" was also there by mistake