### PR TITLE
fix: allow _prequential_evaluation_fast to store y and predictions

### DIFF
--- a/invoke.yml
+++ b/invoke.yml
@@ -5,7 +5,7 @@ moa_path: "src/capymoa/jar/moa.jar"
 # DROPBOX: When using a dropbox link, ensure that the dl=1 query parameter is 
 # present in the link. This ensures  the file is downloaded directly instead
 # of going to the dropbox page
-moa_url: "https://www.dropbox.com/scl/fi/tiotxvygfbb6ql2w904b3/240520_moa.jar?rlkey=q0p1qj47t2nj9gbo76b94pajp&st=bva4d3wx&dl=1"
+moa_url: "https://www.dropbox.com/scl/fi/88tlv50fdkn7js0hpfgvw/240522_moa.jar?rlkey=a06ap3utady3l4fz6xh85cb0n&st=m31fee1u&dl=1"
 
 # What notebooks to skip when running them as tests.
 test_skip_notebooks:

--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -921,6 +921,8 @@ def _test_then_train_evaluation_fast(
             None,
             max_instances,
             -1,
+            False,
+            False,
         )
 
     # Stop measuring time

--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -902,6 +902,8 @@ def _test_then_train_evaluation_fast(
             evaluator.moa_basic_evaluator,
             max_instances,
             sample_frequency,
+            False,
+            False,
         )
         # Reset the windowed_evaluator result_windows
         if moa_results is not None:

--- a/tests/test_moajar.py
+++ b/tests/test_moajar.py
@@ -4,7 +4,7 @@ from hashlib import sha256
 import warnings
 import os
 
-_MOA_JAR_HASH = "88455bef67d694c8ff3926ade33fe51ce7fdb3e65e4577838866761a7a079c7d"
+_MOA_JAR_HASH = "c10abb16c87186f0da887d4a05e755117ce72eb695061735a5148b865979a8c6"
 
 
 def test_imports():


### PR DESCRIPTION
Amended `evaluation.py` to allow fast prequential evaluation to store targets and predictions