### PR TITLE
feat(STREAM): change the logic when dealing with csv input

### DIFF
--- a/src/capymoa/instance.py
+++ b/src/capymoa/instance.py
@@ -291,7 +291,7 @@ class RegressionInstance(Instance):
         >>> schema = Schema.from_custom(
         ...     ["f1", "f2"],
         ...     dataset_name="CustomDataset",
-        ...     enforce_regression=True
+        ...     target_type='numeric'
         ... )
         >>> x = np.array([0.1, 0.2])
         >>> instance = RegressionInstance.from_array(schema, x, 0.5)

--- a/src/capymoa/stream/PytorchStream.py
+++ b/src/capymoa/stream/PytorchStream.py
@@ -47,7 +47,7 @@ class PytorchStream(Stream):
     """
 
     # https://pytorch.org/tutorials/beginner/basics/data_tutorial.html
-    def __init__(self, dataset: Dataset, enforce_regression=False):
+    def __init__(self, dataset: Dataset, target_type='categorical'):
         """Construct PytorchStream from a PyTorch dataset.
 
         :param dataset: PyTorch containing tuples of `x` and `y`
@@ -70,7 +70,7 @@ class PytorchStream(Stream):
                 values_for_class_label=self.training_data.classes,
                 dataset_name="PytorchDataset",
                 target_attribute_name=None,
-                enforce_regression=enforce_regression,
+                target_type=target_type,
             )
         )
 

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -436,7 +436,7 @@ def stream_from_file(
     :param path_to_csv_or_arff: A file path to a CSV or ARFF file.
     :param dataset_name: A descriptive name given to the dataset, defaults to "NoName"
     :param target_type: When working with a CSV file, this parameter
-        allows the user to specify the target values in the data to be interpreted as a categorical or numeri.
+        allows the user to specify the target values in the data to be interpreted as categorical or numeric.
         Defaults to None to detect automatically.
     """
     assert path_to_csv_or_arff is not None, "A file path must be provided."
@@ -447,8 +447,9 @@ def stream_from_file(
         # TODO: Upgrade to CSVStream once its faster and notebook tests don't fail
         x_features = np.genfromtxt(path_to_csv_or_arff, delimiter=",", skip_header=1)
         targets = x_features[:, class_index]
+        if _target_is_categorical(targets, target_type) and type(targets[0]) == np.float64:
+            targets = targets.astype(np.int64)
         x_features = np.delete(x_features, class_index, axis=1)
-        # targets = targets.astype(type(targets[0]))
         return NumpyStream(
             x_features,
             targets,

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -178,7 +178,7 @@ class Schema:
         ...     values_for_nominal_features={"attrib_1": ["a", "b"]},
         ...     dataset_name="MyRegression",
         ...     target_attribute_name="target",
-        ...     enforce_numeric_target=True)
+        ...     target_type='numeric')
         @relation MyRegression
         <BLANKLINE>
         @attribute attrib_1 {a,b}

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -344,7 +344,7 @@ class NumpyStream(Stream):
         dataset_name="No_Name",
         feature_names=None,
         target_name=None,
-        target_type: None | str = None,   # numeric or categorical
+        target_type: str = None,   # numeric or categorical
     ):
         """Construct a NumpyStream object from a numpy array.
 
@@ -417,7 +417,7 @@ def stream_from_file(
     path_to_csv_or_arff: str = None,
     dataset_name: str = "NoName",
     class_index: int = -1,
-    target_type: None | str = None,  # "numeric" or "categorical"
+    target_type: str = None,  # "numeric" or "categorical"
 ) -> Stream:
     """Create a datastream from a csv or arff file.
 
@@ -463,7 +463,7 @@ def _numpy_to_ARFF(
     dataset_name: str ="No_Name",
     feature_names: str =None,
     target_name: str =None,
-    target_type: None | str = None,
+    target_type: str = None,
 ):
     """Converts a numpy X and y into a ARFF format. The code first check if the user has specified the type of the
     target values, if not, the code infers whether it is a categorical or numeric target by _target_is_categorical
@@ -595,7 +595,7 @@ class CSVStream(Stream):
         class_index: int = -1,
         values_for_class_label: list = None,
         target_attribute_name=None,
-        target_type: None | str = None,
+        target_type: str = None,
         skip_header: bool = False,
         delimiter=",",
     ):

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -27,7 +27,7 @@ def _target_is_categorical(targets, target_type):
     if target_type is None:
         if type(targets[0]) == str or type(targets[0]) == bool:
             return True
-        if type(targets[0]) == np.float64:
+        if type(targets[0]) == np.float64 or type(targets[0]) == np.int64:
             num_unique = len(np.unique(targets))
             if num_unique >= 20:
                 warnings.warn(f'target variable includes {num_unique} (≥ 20) unique values, inferred as numeric, '

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -504,7 +504,7 @@ def _init_moa_stream_and_create_moa_header(
     values_for_class_label: list = None,
     dataset_name="No_Name",
     target_attribute_name=None,
-    target_type: None|str =None,  # 'categorical' or 'numeric'
+    target_type: str =None,  # 'categorical' or 'numeric'
 ):
     """Initialize a moa stream with number_of_instances capacity and create a mao header which contains all the necessary
      attribute information.

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -413,9 +413,6 @@ class NumpyStream(Stream):
         self.current_instance_index = 0
 
 
-# TODO (20/10/2023): Add logic to interpret nominal values (strings) in the class label.
-# TODO: implement class_index logic when reading from a CSV.
-# TODO: path_to_csv_or_arff should be a positional argument because it is required.
 def stream_from_file(
     path_to_csv_or_arff: str,
     dataset_name: str = "NoName",
@@ -438,7 +435,7 @@ def stream_from_file(
 
     :param path_to_csv_or_arff: A file path to a CSV or ARFF file.
     :param dataset_name: A descriptive name given to the dataset, defaults to "NoName"
-    ::param class_index: The index of the column containing the class label. By default, the algorithm assumes that the
+    :param class_index: The index of the column containing the class label. By default, the algorithm assumes that the
         class label is located in the column specified by this index. However, if the class label is located in a
         different column, you can specify its index using this parameter.
     :param target_type: When working with a CSV file, this parameter

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -67,7 +67,7 @@ def test_batch_basic():
     y = np.arange(n)
     assert x.shape == (n, feature_count)
 
-    stream = NumpyStream(x, y)
+    stream = NumpyStream(x, y, target_type='categorical')
     learner = _DummyBatchClassifierSSL(batch_size, stream.schema, class_value_type=str)
     prequential_ssl_evaluation(
         stream=stream, learner=learner, label_probability=0.01, window_size=100

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -76,7 +76,7 @@ def test_regressor(learner_constructor, rmse, win_rmse):
 
 def test_none_predict():
     """Test that a prediction of None is handled."""
-    schema = Schema.from_custom(feature_names=["x"], target_attribute_name="y", enforce_regression=True)
+    schema = Schema.from_custom(feature_names=["x"], target_attribute_name="y", target_type='numeric')
     evaluator = RegressionEvaluator(schema=schema)
     win_evaluator = RegressionWindowedEvaluator(schema=schema, window_size=100)
     evaluator.update(1.0, None)


### PR DESCRIPTION
-- Add function to automatically determine the target type base on the number of unique values in the target
-- Remove the `enforce_regression` functionality
-- Add `target_type` functionality to allow users to specify the target type as 'categorical' or 'numeric', `None` to auto-determine
-- Allow target index functionality for csv input, users now can set the index of the target a the csv stream