### PR TITLE
fix: fix issue saving and loading models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
 # Development dependencies
 dev=[
     "pytest",
+    "pytest-subtests",
     "jupyter",
     "nbmake",
     "pytest-xdist",

--- a/src/capymoa/_pickle.py
+++ b/src/capymoa/_pickle.py
@@ -1,0 +1,133 @@
+"""This file is a hacky workaround for https://github.com/jpype-project/jpype/issues/1201
+TODO: When the issue is resolved, remove this file and update the required
+version of JPype to the one that includes the fix.
+
+This is a patched version of https://github.com/jpype-project/jpype/blob/653ccffd1df46e4d472217d77f592326ae3d3690/jpype/pickle.py
+"""
+
+# *****************************************************************************
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   See NOTICE file for details.
+#
+# *****************************************************************************
+
+import _jpype
+import pickle
+from copyreg import dispatch_table
+
+__ALL__ = ['JPickler', 'JUnpickler']
+
+# This must exist as a global, the real unserializer is created by the JUnpickler
+
+def encode(object_):
+    from java.io import ObjectOutputStream, ByteArrayOutputStream
+
+    o_stream = ByteArrayOutputStream()
+    oo_stream = ObjectOutputStream(o_stream)
+    oo_stream.writeObject(object_)
+    return o_stream.toByteArray()
+
+class JUnserializer(object):
+    def __call__(self, *args):
+        raise pickle.UnpicklingError("Unpickling Java requires JUnpickler")
+
+
+class _JDispatch(object):
+    """Dispatch for Java classes and objects.
+
+    Python does not have a good way to register a reducer that applies to
+    many classes, thus we will substitute the usual dictionary with a
+    class that can produce reducers as needed.
+    """
+
+    def __init__(self, dispatch):
+        self._builder = JUnserializer()
+        self._dispatch = dispatch
+
+        # Extension dispatch table holds reduce method
+        self._call = self.reduce
+
+    # Pure Python _Pickler uses get()
+    def get(self, cls):
+        if not issubclass(cls, (_jpype.JClass, _jpype.JObject)):
+            return self._dispatch.get(cls)
+        return self._call
+
+    # Python3 cPickler uses __getitem__()
+    def __getitem__(self, cls):
+        if not issubclass(cls, (_jpype.JClass, _jpype.JObject)):
+            return self._dispatch[cls]
+        return self._call
+
+    def reduce(self, obj):
+        byte = bytes(encode(obj))
+        return (self._builder, (byte, ))
+
+
+class JPickler(pickle.Pickler):
+    """Pickler overloaded to support Java objects
+
+    Parameters:
+        file: a file or other writeable object.
+        *args: any arguments support by the native pickler.
+
+    Raises:
+        java.io.NotSerializableException: if a class is not serializable or
+            one of its members
+        java.io.InvalidClassException: an error occures in constructing a
+            serialization.
+
+    """
+
+    def __init__(self, file, *args, **kwargs):
+        pickle.Pickler.__init__(self, file, *args, **kwargs)
+
+        # In Python3 we need to hook into the dispatch table for extensions
+        self.dispatch_table = _JDispatch(dispatch_table)
+
+
+class JUnpickler(pickle.Unpickler):
+    """Unpickler overloaded to support Java objects
+
+    Parameters:
+        file: a file or other readable object.
+        *args: any arguments support by the native unpickler.
+
+    Raises:
+        java.lang.ClassNotFoundException: if a serialized class is not
+            found by the current classloader.
+        java.io.InvalidClassException: if the serialVersionUID for the
+            class does not match, usually as a result of a new jar
+            version.
+        java.io.StreamCorruptedException: if the pickle file has been
+            altered or corrupted.
+
+    """
+
+    def __init__(self, file, *args, **kwargs):
+        pickle.Unpickler.__init__(self, file, *args, **kwargs)
+
+    def find_class(self, module, cls):
+        """Specialization for Java classes.
+
+        We just need to substitute the stub class for a real
+        one which points to our decoder instance.
+        """
+        if cls == "JUnserializer":
+            class JUnserializer(object):
+                def __call__(self, *args):
+                    return _jpype.JClass('org.jpype.pickle.Decoder')().unpack(args[0])
+            return JUnserializer
+        return pickle.Unpickler.find_class(self, module, cls)

--- a/src/capymoa/misc.py
+++ b/src/capymoa/misc.py
@@ -1,4 +1,4 @@
-from jpype.pickle import JPickler, JUnpickler
+from capymoa._pickle import JPickler, JUnpickler
 
 
 def save_model(model, filename):

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+from dataclasses import dataclass
 from capymoa.evaluation import ClassificationEvaluator, ClassificationWindowedEvaluator
 from capymoa.classifier import (
     EFDT,
@@ -22,96 +24,242 @@ from capymoa.classifier import (
 from capymoa.base import Classifier
 from capymoa.base import MOAClassifier
 from capymoa.datasets import ElectricityTiny
+from capymoa.misc import save_model, load_model
+from java.lang import Exception as JException
 import pytest
 from functools import partial
 from typing import Callable, Optional
 from capymoa.base import _extract_moa_learner_CLI
 from capymoa.splitcriteria import GiniSplitCriterion
 
-from capymoa.stream._stream import Schema
+from capymoa.stream import Schema, Stream
 
 from capymoa.classifier import PassiveAggressiveClassifier, SGDClassifier
+from pytest_subtests import SubTests
+from tempfile import TemporaryDirectory
+import os
+
+
+@dataclass
+class ClassifierTestCase:
+    test_name: str
+    """A unique name to identify your test case. Usually the name of the learner."""
+    learner_constructor: Callable[[Schema], Classifier]
+    """A function that returns a new instance of the learner."""
+    accuracy: float
+    """The expected accuracy of the learner."""
+    win_accuracy: float
+    """The expected windowed accuracy of the learner."""
+    cli_string: Optional[str] = None
+    """The expected CLI string of the learner."""
+    is_serializable: bool = True
+    """Whether the learner is serializable."""
+
+
+"""
+Add your test cases here. Each test case is a `ClassifierTestCase` object
+
+Notice how we use the `partial` function to creates a new function with
+hyperparameters already set. This allows us to use the same test function
+for different learners with different hyperparameters.
+"""
+test_cases = [
+    ClassifierTestCase(
+        "OnlineBagging",
+        partial(OnlineBagging, ensemble_size=5),
+        84.6,
+        89.0,
+    ),
+    ClassifierTestCase(
+        "AdaptiveRandomForestClassifier",
+        partial(AdaptiveRandomForestClassifier),
+        89.0,
+        91.0,
+    ),
+    ClassifierTestCase(
+        "HoeffdingTree",
+        partial(HoeffdingTree),
+        82.65,
+        83.0,
+    ),
+    ClassifierTestCase(
+        "EFDT",
+        partial(EFDT),
+        82.69,
+        82.0,
+    ),
+    ClassifierTestCase(
+        "EFDT",
+        partial(
+            EFDT,
+            grace_period=10,
+            split_criterion=GiniSplitCriterion(),
+            leaf_prediction="NaiveBayes",
+        ),
+        87.8,
+        85.0,
+        cli_string="trees.EFDT -R 200 -m 33554433 -g 10 -s GiniSplitCriterion -c 0.001 -z -p -l NB",
+    ),
+    ClassifierTestCase(
+        "NaiveBayes",
+        partial(NaiveBayes),
+        84.0,
+        91.0,
+    ),
+    ClassifierTestCase(
+        "KNN",
+        partial(KNN),
+        81.6,
+        74.0,
+    ),
+    ClassifierTestCase(
+        "PassiveAggressiveClassifier",
+        partial(PassiveAggressiveClassifier),
+        84.7,
+        81.0,
+    ),
+    ClassifierTestCase(
+        "SGDClassifier",
+        partial(SGDClassifier),
+        84.7,
+        83.0,
+    ),
+    ClassifierTestCase(
+        "StreamingGradientBoostedTrees",
+        partial(StreamingGradientBoostedTrees),
+        88.75,
+        88.0,
+    ),
+    ClassifierTestCase(
+        "OzaBoost",
+        partial(OzaBoost),
+        89.95,
+        89.0,
+    ),
+    ClassifierTestCase(
+        "MajorityClass",
+        partial(MajorityClass),
+        60.199999999999996,
+        66.0,
+    ),
+    ClassifierTestCase(
+        "NoChange",
+        partial(NoChange),
+        85.95,
+        81.0,
+    ),
+    ClassifierTestCase(
+        "OnlineSmoothBoost",
+        partial(OnlineSmoothBoost),
+        87.85,
+        90.0,
+    ),
+    ClassifierTestCase(
+        "StreamingRandomPatches",
+        partial(StreamingRandomPatches),
+        90.2,
+        89.0,
+        is_serializable=False,
+    ),
+    ClassifierTestCase(
+        "HoeffdingAdaptiveTree",
+        partial(HoeffdingAdaptiveTree),
+        84.15,
+        92.0,
+    ),
+    ClassifierTestCase(
+        "SAMkNN",
+        partial(SAMkNN),
+        82.65,
+        82.0,
+    ),
+    ClassifierTestCase(
+        "DynamicWeightedMajority",
+        partial(DynamicWeightedMajority),
+        84.05,
+        89.0,
+    ),
+    ClassifierTestCase(
+        "CSMOTE",
+        partial(CSMOTE),
+        80.55,
+        79.0,
+    ),
+    ClassifierTestCase(
+        "LeveragingBagging",
+        partial(LeveragingBagging),
+        86.7,
+        91.0,
+    ),
+    ClassifierTestCase(
+        "OnlineAdwinBagging",
+        partial(OnlineAdwinBagging),
+        85.25,
+        92.0,
+    ),
+]
+
+
+def _score(classifier: Classifier, stream: Stream, limit=100) -> float:
+    """Eval without training the classifier."""
+    stream.restart()
+    evaluator = ClassificationEvaluator(schema=stream.get_schema())
+    i = 0
+    while stream.has_more_instances():
+        instance = stream.next_instance()
+        prediction = classifier.predict(instance)
+        evaluator.update(instance.y_index, prediction)
+        i += 1
+        if i > limit:
+            break
+
+    return evaluator.accuracy()
+
+
+def subtest_save_and_load(
+    classifier: Classifier,
+    stream: Stream,
+    is_serializable: bool,
+):
+    """A subtest to check if a classifier can be saved and loaded."""
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_file = os.path.join(tmp_dir, "model.pkl")
+        with pytest.raises(JException) if not is_serializable else nullcontext():
+            # Save and load the model
+            save_model(classifier, tmp_file)
+            loaded_classifier: Classifier = load_model(tmp_file)
+
+            # Check that the saved and loaded model have the same accuracy
+            expected_acc = _score(classifier, stream)
+            loaded_acc = _score(loaded_classifier, stream)
+            assert (
+                expected_acc == loaded_acc
+            ), f"Original accuracy {expected_acc*100:.2f} != loaded accuracy {loaded_acc*100:.2f}"
+
+            # Check that the loaded model can still be trained
+            loaded_classifier.train(stream.next_instance())
 
 
 @pytest.mark.parametrize(
-    "learner_constructor,accuracy,win_accuracy,cli_string",
-    [
-        (partial(OnlineBagging, ensemble_size=5), 84.6, 89.0, None),
-        (partial(AdaptiveRandomForestClassifier), 89.0, 91.0, None),
-        (partial(HoeffdingTree), 82.65, 83.0, None),
-        (partial(EFDT), 82.69, 82.0, None),
-        (
-            partial(EFDT, grace_period=10, split_criterion=GiniSplitCriterion(), leaf_prediction="NaiveBayes"),
-            87.8,
-            85.0,
-            "trees.EFDT -R 200 -m 33554433 -g 10 -s GiniSplitCriterion -c 0.001 -z -p -l NB",
-        ),
-        (partial(NaiveBayes), 84.0, 91.0, None),
-        (partial(KNN), 81.6, 74.0, None),
-        (partial(PassiveAggressiveClassifier), 84.7, 81.0, None),
-        (partial(SGDClassifier), 84.7, 83.0, None),
-        (partial(StreamingGradientBoostedTrees), 88.75, 88.0, None),
-        (partial(OzaBoost), 89.95, 89.0, None),
-        (partial(MajorityClass), 60.199999999999996, 66.0, None),
-        (partial(NoChange), 85.95, 81.0, None),
-        (partial(OnlineSmoothBoost), 87.85, 90.0, None),
-        (partial(StreamingRandomPatches), 90.2, 89.0, None),
-        (partial(HoeffdingAdaptiveTree), 84.15, 92.0, None),
-        (partial(SAMkNN), 82.65, 82.0, None),
-        (partial(DynamicWeightedMajority), 84.05, 89.0, None),
-        (partial(CSMOTE), 80.55, 79.0, None),
-        (partial(LeveragingBagging), 86.7, 91.0, None),
-        (partial(OnlineAdwinBagging), 85.25, 92.0, None),
-    ],
-    ids=[
-        "OnlineBagging",
-        "AdaptiveRandomForest",
-        "HoeffdingTree",
-        "EFDT",
-        "EFDT_gini",
-        "NaiveBayes",
-        "KNN",
-        "PassiveAggressiveClassifier",
-        "SGDClassifier",
-        "StreamingGradientBoostedTrees",
-        "OzaBoost",
-        "MajorityClass",
-        "NoChange",
-        "OnlineSmoothBoost",
-        "StreamingRandomPatches",
-        "HoeffdingAdaptiveTree",
-        "SAMkNN",
-        "DynamicWeightedMajority",
-        "CSMOTE",
-        "LeveragingBagging",
-        "OnlineAdwinBagging",
-    ],
+    "test_case",
+    test_cases,
+    ids=[c.test_name for c in test_cases],
 )
-def test_classifiers(
-    learner_constructor: Callable[[Schema], Classifier],
-    accuracy: float,
-    win_accuracy: float,
-    cli_string: Optional[str],
-):
-    """Test on tiny is a fast running simple test to check if a learner's
-    accuracy has changed.
+def test_classifiers(test_case: ClassifierTestCase, subtests: SubTests):
+    """``test_classifiers`` is a fast running complex test that checks:
 
-    Notice how we use the `partial` function to creates a new function with
-    hyperparameters already set. This allows us to use the same test function
-    for different learners with different hyperparameters.
-
-    :param learner_constructor: A partially applied constructor for the learner
-    :param accuracy: Expected accuracy
-    :param win_accuracy: Expected windowed accuracy
-    :param cli_string: Expected CLI string for the learner or None
+    * Did the classifier reach the expected accuracy?
+    * Did the classifier reach the expected windowed accuracy?
+    * Can the classifier be saved and loaded?
+    * Does the CLI string match the expected value?
     """
     stream = ElectricityTiny()
     evaluator = ClassificationEvaluator(schema=stream.get_schema())
     win_evaluator = ClassificationWindowedEvaluator(
         schema=stream.get_schema(), window_size=100
     )
-
-    learner: Classifier = learner_constructor(schema=stream.get_schema())
+    learner: Classifier = test_case.learner_constructor(schema=stream.get_schema())
 
     while stream.has_more_instances():
         instance = stream.next_instance()
@@ -124,13 +272,17 @@ def test_classifiers(
     actual_acc = evaluator.accuracy()
     actual_win_acc = win_evaluator.accuracy()
     assert actual_acc == pytest.approx(
-        accuracy, abs=0.1
-    ), f"Basic Eval: Expected accuracy of {accuracy:0.1f} got {actual_acc: 0.1f}"
+        test_case.accuracy, abs=0.1
+    ), f"Basic Eval: Expected accuracy of {test_case.accuracy:0.1f} got {actual_acc: 0.1f}"
     assert actual_win_acc == pytest.approx(
-        win_accuracy, abs=0.1
-    ), f"Windowed Eval: Expected accuracy of {win_accuracy:0.1f} got {actual_win_acc:0.1f}"
+        test_case.win_accuracy, abs=0.1
+    ), f"Windowed Eval: Expected accuracy of {test_case.win_accuracy:0.1f} got {actual_win_acc:0.1f}"
+
+    # Check if the classifier can be saved and loaded
+    with subtests.test(msg="save_and_load"):
+        subtest_save_and_load(learner, stream, test_case.is_serializable)
 
     # Optionally check the CLI string if it was provided
-    if isinstance(learner, MOAClassifier) and cli_string is not None:
+    if isinstance(learner, MOAClassifier) and test_case.cli_string is not None:
         cli_str = _extract_moa_learner_CLI(learner).strip("()")
-        assert cli_str == cli_string, "CLI does not match expected value"
+        assert cli_str == test_case.cli_string, "CLI does not match expected value"

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -1,5 +1,8 @@
+from contextlib import nullcontext
+import os
 from capymoa.evaluation import RegressionEvaluator, RegressionWindowedEvaluator
 from capymoa.datasets import Fried
+from capymoa.misc import load_model, save_model
 from capymoa.regressor import (
     KNNRegressor,
     AdaptiveRandomForestRegressor,
@@ -11,11 +14,55 @@ from capymoa.regressor import (
     PassiveAggressiveRegressor,
     SGDRegressor
 )
+from jpype import JException
 import pytest
 from functools import partial
 
 from capymoa.base import Regressor
-from capymoa.stream import Schema
+from capymoa.stream import Schema, Stream
+from tempfile import TemporaryDirectory
+
+from pytest_subtests import SubTests
+
+def _score(classifier: Regressor, stream: Stream, limit=100) -> float:
+    """Eval without training the classifier."""
+    stream.restart()
+    evaluator = RegressionEvaluator(schema=stream.get_schema())
+    i = 0
+    while stream.has_more_instances():
+        instance = stream.next_instance()
+        prediction = classifier.predict(instance)
+        evaluator.update(instance.y_value, prediction)
+        i += 1
+        if i > limit:
+            break
+
+    return evaluator.MAE()
+
+
+def subtest_save_and_load(
+    regressor: Regressor,
+    stream: Stream,
+    is_serializable: bool,
+):
+    """A subtest to check if a classifier can be saved and loaded."""
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_file = os.path.join(tmp_dir, "model.pkl")
+        with pytest.raises(JException) if not is_serializable else nullcontext():
+            # Save and load the model
+            save_model(regressor, tmp_file)
+            loaded_regressor: Regressor = load_model(tmp_file)
+
+            # Check that the saved and loaded model have the same accuracy
+            expected_acc = _score(regressor, stream)
+            loaded_acc = _score(loaded_regressor, stream)
+            assert (
+                expected_acc == loaded_acc
+            ), f"Original accuracy {expected_acc*100:.2f} != loaded accuracy {loaded_acc*100:.2f}"
+
+            # Check that the loaded model can still be trained
+            loaded_regressor.train(stream.next_instance())
 
 @pytest.mark.parametrize(
     "learner_constructor,rmse,win_rmse",
@@ -42,7 +89,7 @@ from capymoa.stream import Schema
         "SGDRegressor"
     ]
 )
-def test_regressor(learner_constructor, rmse, win_rmse):
+def test_regressor(subtests: SubTests, learner_constructor, rmse, win_rmse):
     """Test on tiny is a fast running simple test to check if a learner's
     accuracy has changed.
 
@@ -73,6 +120,9 @@ def test_regressor(learner_constructor, rmse, win_rmse):
         f"Basic Eval: Expected {rmse:0.1f} RMSE got {actual_rmse: 0.1f} RMSE"
     assert actual_win_rmse == pytest.approx(win_rmse, abs=0.1), \
         f"Windowed Eval: Expected {win_rmse:0.1f} RMSE got {actual_win_rmse:0.1f} RMSE"
+    
+    with subtests.test(msg="save_and_load"):
+        subtest_save_and_load(learner, stream, True)
 
 def test_none_predict():
     """Test that a prediction of None is handled."""


### PR DESCRIPTION
- Add a subtest to check loading/saving every model works.
- Adds a workaround for https://github.com/jpype-project/jpype/issues/1201. Avoids the buffer overflow by allocating a new output object stream for each object. The bug only arises when the same stream is reused.
- There is a possibility that models saved with this patch won't work when jpype is fixed.