### PR TITLE
fix: leveragingbagging parameter configuration 

### DIFF
--- a/src/capymoa/classifier/_leveraging_bagging.py
+++ b/src/capymoa/classifier/_leveraging_bagging.py
@@ -81,12 +81,13 @@ class LeveragingBagging(MOAClassifier):
                     self.number_of_jobs = os.cpu_count()
                 else:
                     self.number_of_jobs = int(min(number_of_jobs, os.cpu_count()))
-                if minibatch_size <= 1:
-                    # if the user sets the number of jobs and the minibatch_size less than 1 it is considered that the user wants a parallel execution of a single instance at a time
-                    self.minibatch_size = 1
-                elif minibatch_size is None:
+                
+                if minibatch_size is None:
                     # if the user sets only the number_of_jobs, we assume he wants the parallel minibatch version and initialize minibatch_size to the default 25
                     self.minibatch_size = 25
+                elif minibatch_size <= 1:
+                    # if the user sets the number of jobs and the minibatch_size less than 1 it is considered that the user wants a parallel execution of a single instance at a time
+                    self.minibatch_size = 1
                 else:
                     # if the user sets both parameters to values greater than 1, we initialize the minibatch_size to the user's choice
                     self.minibatch_size = int(minibatch_size)


### PR DESCRIPTION
**Issue**
While tuning hyper-parameters with a `LeverageBagging` classifier, I got an error when specifying the number_of_jobs but without using the `minbatch_size` parameter.
On instantiation, the classifier checks `if minibatch_size <= 1` but `minibatch` is still `None`. This raises an exception.

**Proposed solution**
Switch the test order for `minibatch_size`, starting with the `is None` test.
The existing comments and documentation are still relevant.