### PR TITLE
build: use python 3.10, 3.11, and 3.12

### DIFF
--- a/.github/workflows/all_targets.yml
+++ b/.github/workflows/all_targets.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Python 3.9->3.11 on Ubuntu, Windows and MacOS
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -26,12 +26,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip" # caching pip dependencies
+
+      - name: CPU PyTorch (Windows/MacOS)
+        if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'macos-latest'
+        run: python -m pip install torch torchvision
+
+      - name: CPU PyTorch (Linux)
+        if: matrix.operating-system == 'ubuntu-latest'
+        run: python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+              
       - name: Install dependencies
-        run: |
-          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install ".[dev]"
+        run: python -m pip install ".[dev]"
+
       - name: PyTest
         run: invoke test.unit
+
       - name: Notebooks
         run: invoke test.nb
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             operating-system: ubuntu-latest
 
     steps:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 This document describes how to install CapyMOA and its dependencies. CapyMOA is
-tested against Python 3.9, 3.10, and 3.11. Newer versions of Python will likely
+tested against Python 3.10, 3.11, and 3.12. Newer versions of Python will likely
 work but have yet to be tested.
 
 #. **Virtual Environment (Optional)**

--- a/src/capymoa/regressor/_passive_aggressive_regressor.py
+++ b/src/capymoa/regressor/_passive_aggressive_regressor.py
@@ -28,7 +28,7 @@ class PassiveAggressiveRegressor(SKRegressor):
     >>> learner = PassiveAggressiveRegressor(schema)
     >>> results = prequential_evaluation(stream, learner, max_instances=1000)
     >>> results["cumulative"].rmse()
-    3.7004531627005455
+    3.700...
     """
 
     sklearner: _SKPassiveAggressiveRegressor


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/98cd88e1-bc59-45bb-9f7e-29e42c191eab)

PyTorch does not support python 3.13 on MacOS