### PR TITLE
ci: set sphinx 8.1.3 and add ruff target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev=[
 
 doc=[
     # Documentation generator
-    "sphinx",
+    "sphinx==8.1.3",
     # Theme for the documentation
     "pydata-sphinx-theme",
     # Allows to include Jupyter notebooks in the documentation
@@ -201,3 +201,7 @@ style = "sphinx"
 fail-under = 80
 omit-covered-files = true
 ignore-module = true
+
+# Configuration for the formatter
+[tool.ruff]
+target-version = "py310"


### PR DESCRIPTION
The  recent  version of sphinx 8.2.0 broke our documentation build. Might be related to https://github.com/spatialaudio/nbsphinx/issues/825 .

```
...
reading sources... [100%] tutorials

/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/00_getting_started.ipynb:640: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_00_getting_started_7_1.png [image.not_readable]
/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/00_getting_started.ipynb:695: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_00_getting_started_9_0.png [image.not_readable]
/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/00_getting_started.ipynb:797: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_00_getting_started_12_1.png [image.not_readable]
/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/01_evaluation.ipynb:914: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_01_evaluation_6_2.png [image.not_readable]
/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/01_evaluation.ipynb:993: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_01_evaluation_8_1.png [image.not_readable]
/home/antonlee/github.com/tachyonicClock/CapyMOA/docs/notebooks/01_evaluation.ipynb:1075: WARNING: image file not readable: ../_build/.doctrees/nbsphinx/notebooks_01_evaluation_10_1.png [image.not_readable]
...
```