### PR TITLE
fix(OnlineIsolationForest): add random generator to assign unique seeds to OnlineIsolationTrees

### DIFF
--- a/tests/test_anomaly_detectors.py
+++ b/tests/test_anomaly_detectors.py
@@ -30,7 +30,7 @@ from capymoa.stream._stream import Schema
                 num_trees=32,
                 max_leaf_samples=32,
             ),
-            0.50,
+            0.42,
             None,
         ),
         (


### PR DESCRIPTION
Hi everyone,
This pull request implements Danshi's suggestion to add a random generator to OnlineIsolationForest, ensuring each OnlineIsolationTree has a unique random seed.
Previously, I was passing the same seed to every tree, which made them identical and negatively impacted the ensemble's performance.
Thank you.