### PR TITLE
fix: handle ValueError in fast mode compilation for anomaly evaluation

### DIFF
--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -1282,7 +1282,7 @@ def prequential_evaluation_anomaly(
                 stream, learner, max_instances, window_size, store_y, store_predictions
             )
     except ValueError:
-        pass # If the stream is not compatible, just ignore the error and continue with the normal evaluation.
+        pass  # If the stream is not compatible, just ignore the error and continue with the normal evaluation.
 
     predictions = None
     if store_predictions:

--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -1276,10 +1276,13 @@ def prequential_evaluation_anomaly(
         incompatible with ``optimize=True``.
     """
     stream.restart()
-    if _is_fast_mode_compilable(stream, learner, optimise):
-        return _prequential_evaluation_anomaly_fast(
-            stream, learner, max_instances, window_size, store_y, store_predictions
-        )
+    try:
+        if _is_fast_mode_compilable(stream, learner, optimise):
+            return _prequential_evaluation_anomaly_fast(
+                stream, learner, max_instances, window_size, store_y, store_predictions
+            )
+    except ValueError:
+        pass # If the stream is not compatible, just ignore the error and continue with the normal evaluation.
 
     predictions = None
     if store_predictions:


### PR DESCRIPTION
The following code will cause an exception.

```
import numpy as np
from sklearn.datasets import make_blobs
import matplotlib.pyplot as plt
from capymoa.stream import NumpyStream, Schema
from capymoa.instance import LabeledInstance, RegressionInstance

from capymoa.evaluation.visualization import plot_windowed_results
from capymoa.anomaly import HalfSpaceTrees, Autoencoder, OnlineIsolationForest
from capymoa.evaluation import prequential_evaluation_anomaly


# generate normal data points
n_samples = 10000
n_features = 2
n_clusters = 3
n_anomalies = 500

X, y = make_blobs(n_samples=n_samples, n_features=n_features, centers=n_clusters, random_state=42)

# generate anomalous data points
anomalies = np.random.uniform(low=-10, high=10, size=(n_anomalies, n_features))

# combine the normal data points with anomalies
X = np.vstack([X, anomalies])
y = np.hstack([y, [1]*n_anomalies])  # Label anomalies with 1
y[:n_samples] = 0  # Label normal points with 0


# create a NumpyStream from the dataset
feature_names = [f"feature_{i}" for i in range(n_features)]
target_name = "class"

stream = NumpyStream(X, y, dataset_name="AnomalyDetectionDataset",
                       feature_names=feature_names, target_name=target_name)
hst = HalfSpaceTrees(schema=stream.get_schema())

results_hst = prequential_evaluation_anomaly(stream=stream, learner=hst, window_size=100, store_predictions=True, store_y=True, optimise=False, max_instances=1000)

print(f"[HalfSpaceTrees] AUC: {results_hst.auc()} wallclock: {results_hst.wallclock()}")
```

The reason is that NumpyStream is incompatible with fast mode and raises a ValueError exception.  We can handle this exception and continue using the default mode.