### PR TITLE
refactor(ocl): change project structure

### DIFF
--- a/docs/contributing/learners.md
+++ b/docs/contributing/learners.md
@@ -29,12 +29,16 @@ from capymoa.classifier import MyNewLearner
 ```
 
 ## What does a learner implement?
-<!-- TODO: Link to capymoa documentation -->
+
 A learner should implement the appropriate interface:
 * {py:class}`capymoa.base.Classifier` for classifiers.
 * {py:class}`capymoa.base.Regressor` for regressors.
 * {py:class}`capymoa.base.AnomalyDetector` for anomaly detectors.
 * {py:class}`capymoa.base.ClassifierSSL` for semi-supervised classifiers.
+* {py:class}`capymoa.base.Classifier` for online continual learning classifiers.
+  Optionally also inheriting from {py:class}`capymoa.ocl.base.TaskAware` or
+  {py:class}`capymoa.ocl.base.TaskBoundaryAware` to support learners that are aware of
+  task identities or task boundaries.
 
 If your method is a wrapper around a MOA learner, you should use the appropriate
 base class:
@@ -48,9 +52,11 @@ the expected performance in future versions. CapyMOA provides parametrized
 tests for classifiers, regressors, and semi-supervised classifiers. You should
 not need to write any new test code. Instead, you should add your test's
 parameters to the appropriate test file:
+
 - `tests/test_classifiers.py` for classifiers.
-- `tests/test_regressors.py` for regressors.
 - `tests/test_ssl_classifiers.py` for semi-supervised classifiers.
+- `tests/ocl/test_learners.py` for online continual learning learners.
+- `tests/test_regressors.py` for regressors.
 - `tests/test_anomaly.py` for anomaly detectors.
 
 To run your tests, use the following command:

--- a/notebooks/10_ocl.ipynb
+++ b/notebooks/10_ocl.ipynb
@@ -274,8 +274,8 @@
     }
    ],
    "source": [
-    "from capymoa.evaluation.ocl import ocl_train_eval_loop\n",
-    "from capymoa.datasets.ocl import SplitMNIST\n",
+    "from capymoa.ocl.evaluation import ocl_train_eval_loop\n",
+    "from capymoa.ocl.datasets import SplitMNIST\n",
     "\n",
     "stream = SplitMNIST()\n",
     "mlp = SimpleMLP(stream.schema, 64)\n",

--- a/notebooks/util/nbmock.py
+++ b/notebooks/util/nbmock.py
@@ -7,12 +7,12 @@ def mock_datasets():
     """Mock the datasets to use the tiny versions for testing."""
     import unittest.mock as mock
     from capymoa.datasets import ElectricityTiny, CovtypeTiny, FriedTiny
-    from capymoa.datasets.ocl import TinySplitMNIST
+    from capymoa.ocl.datasets import TinySplitMNIST
 
     mock.patch("capymoa.datasets.Electricity", ElectricityTiny).start()
     mock.patch("capymoa.datasets.Covtype", CovtypeTiny).start()
     mock.patch("capymoa.datasets.Fried", FriedTiny).start()
-    mock.patch("capymoa.datasets.ocl.SplitMNIST", TinySplitMNIST).start()
+    mock.patch("capymoa.ocl.datasets.SplitMNIST", TinySplitMNIST).start()
 
 
 def is_nb_fast() -> bool:

--- a/src/capymoa/datasets/__init__.py
+++ b/src/capymoa/datasets/__init__.py
@@ -33,7 +33,7 @@ from ._datasets import (
     Sensor,
 )
 from ._utils import get_download_dir
-from . import downloader, ocl
+from . import downloader
 
 __all__ = [
     "Bike",
@@ -50,6 +50,5 @@ __all__ = [
     "RTG_2abrupt",
     "Sensor",
     "downloader",
-    "ocl",
     "get_download_dir",
 ]

--- a/src/capymoa/evaluation/__init__.py
+++ b/src/capymoa/evaluation/__init__.py
@@ -12,7 +12,7 @@ from .evaluation import (
     AnomalyDetectionEvaluator,
     ClusteringEvaluator,
 )
-from . import results, ocl
+from . import results
 
 __all__ = [
     "prequential_evaluation",
@@ -28,5 +28,4 @@ __all__ = [
     "AnomalyDetectionEvaluator",
     "ClusteringEvaluator",
     "results",
-    "ocl",
 ]

--- a/src/capymoa/ocl/__init__.py
+++ b/src/capymoa/ocl/__init__.py
@@ -1,8 +1,8 @@
-"""Learners and base classes for Online Continual Learning.
+"""Online Continual Learning (OCL) module.
 
-Online Continual Learning (OCL) is a setting where learners train on a sequence
-of tasks. A task is a specific concept or data distribution. After training the
-learner on each task, we evaluate the learner on all tasks.
+OCL is a setting where learners train on a sequence of tasks. A task is a
+specific concept or data distribution. After training the learner on each task,
+we evaluate the learner on all tasks.
 
 Continual learning is an important problem to deep learning because these models
 suffer from catastrophic forgetting, which occurs when a model forgets how to
@@ -17,8 +17,8 @@ objective is performance on historic tasks rather than adaptation. Unlike
 traditional continual learning, OCL restricts training to a single data pass.
 
 >>> from capymoa.classifier import HoeffdingTree
->>> from capymoa.datasets.ocl import TinySplitMNIST
->>> from capymoa.evaluation.ocl import ocl_train_eval_loop
+>>> from capymoa.ocl.datasets import TinySplitMNIST
+>>> from capymoa.ocl.evaluation import ocl_train_eval_loop
 >>> import numpy as np
 >>> scenario = TinySplitMNIST()
 >>> learner = HoeffdingTree(scenario.schema)
@@ -52,10 +52,7 @@ Forward Transfer: 0.05
 Backward Transfer: -0.07
 """
 
-from ._base import TaskAware, TaskBoundaryAware
+from . import datasets, base, util, evaluation
 
 
-__all__ = [
-    "TaskAware",
-    "TaskBoundaryAware",
-]
+__all__ = ["evaluation", "datasets", "base", "util"]

--- a/src/capymoa/ocl/base.py
+++ b/src/capymoa/ocl/base.py
@@ -1,3 +1,10 @@
+"""Base classes for online continual learning algorithms.
+
+All OCL learners inherit from :class:`capymoa.base.Classifier` this module
+contains additional base classes for OCL learners that are aware of the task
+boundaries and/or the task identities during training and evaluation.
+"""
+
 from abc import ABC, abstractmethod
 
 
@@ -9,9 +16,9 @@ class TaskBoundaryAware(ABC):
     be mindful and communicate when a learner is task-aware.
 
     >>> from capymoa.classifier import NoChange
-    >>> from capymoa.datasets.ocl import TinySplitMNIST
-    >>> from capymoa.ocl import TaskBoundaryAware
-    >>> from capymoa.evaluation.ocl import ocl_train_eval_loop
+    >>> from capymoa.ocl.datasets import TinySplitMNIST
+    >>> from capymoa.ocl.base import TaskBoundaryAware
+    >>> from capymoa.ocl.evaluation import ocl_train_eval_loop
 
     >>> class MyTaskBoundaryAware(TaskBoundaryAware, NoChange):
     ...     def set_train_task(self, train_task_id: int):
@@ -43,9 +50,9 @@ class TaskAware(TaskBoundaryAware):
     continual learning problem.
 
     >>> from capymoa.classifier import NoChange
-    >>> from capymoa.datasets.ocl import TinySplitMNIST
-    >>> from capymoa.ocl import TaskAware
-    >>> from capymoa.evaluation.ocl import ocl_train_eval_loop
+    >>> from capymoa.ocl.datasets import TinySplitMNIST
+    >>> from capymoa.ocl.base import TaskAware
+    >>> from capymoa.ocl.evaluation import ocl_train_eval_loop
 
     >>> class MyTaskAware(TaskAware, NoChange):
     ...     def set_train_task(self, train_task_id: int):

--- a/src/capymoa/ocl/datasets.py
+++ b/src/capymoa/ocl/datasets.py
@@ -1,4 +1,4 @@
-"""This module contains built-in datastream for online continual learning (OCL).
+"""Use built-in datasets for online continual learning.
 
 In OCL datastreams are irreversible sequences of examples following a
 non-stationary data distribution. Learners in OCL can only learn from a single
@@ -8,15 +8,15 @@ the datastream.
 Portions of the datastream where the data distribution is relatively stationary
 are called *tasks*.
 
-A common way to construct an OCL dataset for experimentation is to groups the
-classes of a usual classification dataset into tasks. Known as the
-*class-incremental* scenario, the learner is presented with a sequence of tasks
-where each task contains a new subset of the classes.
+A common way to construct an OCL dataset for experimentation is to group the
+classes of a classification dataset into tasks. Known as the *class-incremental*
+scenario, the learner is presented with a sequence of tasks where each task
+contains a new subset of the classes.
 
-For example :class:`SplitMNIST` splits the MNIST dataset into five tasks where each
-task contains two classes:
+For example :class:`SplitMNIST` splits the MNIST dataset into five tasks where
+each task contains two classes:
 
->>> from capymoa.datasets.ocl import SplitMNIST
+>>> from capymoa.ocl.datasets import SplitMNIST
 >>> scenario = SplitMNIST()
 >>> scenario.task_schedule
 [{1, 4}, {5, 7}, {9, 3}, {0, 8}, {2, 6}]

--- a/src/capymoa/ocl/evaluation.py
+++ b/src/capymoa/ocl/evaluation.py
@@ -1,3 +1,5 @@
+"""Evaluate online continual learning in classification tasks."""
+
 from typing import Optional, Sequence, Union
 
 from capymoa.base import Classifier
@@ -9,7 +11,7 @@ from capymoa.evaluation.evaluation import (
 )
 from capymoa.evaluation.results import PrequentialResults
 from capymoa.instance import LabeledInstance
-from capymoa.ocl._base import TaskAware, TaskBoundaryAware
+from capymoa.ocl.base import TaskAware, TaskBoundaryAware
 from capymoa.stream import Stream
 
 from capymoa.type_alias import LabelIndex

--- a/src/capymoa/stream/_stream.py
+++ b/src/capymoa/stream/_stream.py
@@ -930,7 +930,9 @@ class CSVStream(Stream[_AnyInstance]):
 
 class ConcatStream(Stream[_AnyInstance]):
     """Concatenate multiple streams into a single stream.
+
     When the end of a stream is reached, the next stream in the list is used.
+
     >>> from capymoa.stream import ConcatStream, NumpyStream
     >>> import numpy as np
     >>> X1 = np.array([[1, 2, 3]])
@@ -954,6 +956,7 @@ class ConcatStream(Stream[_AnyInstance]):
         y_index=0,
         y_label='0'
     )
+
     """
 
     def __init__(self, streams: Sequence[Stream]):
@@ -980,6 +983,7 @@ class ConcatStream(Stream[_AnyInstance]):
 
     def next_instance(self) -> _AnyInstance:
         """Return the next instance in the stream.
+
         :raises ValueError: If the machine learning task is neither a regression
             nor a classification task.
         :return: A labeled instances or a regression depending on the schema.

--- a/tests/ocl/test_datasets.py
+++ b/tests/ocl/test_datasets.py
@@ -1,5 +1,5 @@
 from typing import Type
-from capymoa.datasets import ocl
+from capymoa.ocl import datasets
 from capymoa.stream import Stream
 import numpy as np
 import pytest
@@ -7,22 +7,22 @@ import inspect
 
 ALL_OCL_SCENARIO = [
     cls
-    for _, cls in inspect.getmembers(ocl)
+    for _, cls in inspect.getmembers(datasets)
     if inspect.isclass(cls)
-    and issubclass(cls, ocl._BuiltInCIScenario)
-    and cls != ocl._BuiltInCIScenario
+    and issubclass(cls, datasets._BuiltInCIScenario)
+    and cls != datasets._BuiltInCIScenario
 ]
 
 
 @pytest.mark.parametrize("scenario_type", ALL_OCL_SCENARIO)
 def test_ocl_split_datamodule_constructors(
-    scenario_type: Type[ocl._BuiltInCIScenario],
+    scenario_type: Type[datasets._BuiltInCIScenario],
 ):
     # Skip all except MNIST since downloading datasets can be slow on CI
-    if scenario_type != ocl.TinySplitMNIST:
+    if scenario_type != datasets.TinySplitMNIST:
         pytest.skip("Skipping non-MNIST scenarios")
 
-    scenario: ocl._BuiltInCIScenario = scenario_type()
+    scenario: datasets._BuiltInCIScenario = scenario_type()
     assert isinstance(scenario.train_tasks, list)
     assert isinstance(scenario.test_tasks, list)
     assert isinstance(scenario.train_streams, list)

--- a/tests/ocl/test_learners.py
+++ b/tests/ocl/test_learners.py
@@ -1,0 +1,45 @@
+from typing import List, Callable
+from capymoa.base import Classifier
+from capymoa.stream import Schema
+from dataclasses import dataclass
+import pytest
+from capymoa.ocl.datasets import TinySplitMNIST
+from capymoa.ocl.evaluation import ocl_train_eval_loop
+from functools import partial
+
+from capymoa.classifier import HoeffdingTree
+
+approx = partial(pytest.approx, abs=0.001)
+
+
+@dataclass(frozen=True)
+class Case:
+    """Define a test case for OCL classifiers."""
+
+    name: str
+    constructor: Callable[[Schema], Classifier]
+    accuracy_final: float
+    anytime_accuracy_all_avg: float
+    ttt_accuracy: float
+
+
+"""
+Add new test cases here.
+
+Use the `partial` function to create a new function with hyperparameters already
+set.
+"""
+TEST_CASES: List[Case] = [
+    Case("HoeffdingTree", HoeffdingTree, 0.690, 0.465, 58.5),
+]
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=[test.name for test in TEST_CASES])
+def test_ocl_classifier(case: Case):
+    scenario = TinySplitMNIST()
+    learner = case.constructor(scenario.schema)
+    result = ocl_train_eval_loop(learner, scenario.train_streams, scenario.test_streams)
+
+    assert result.accuracy_final == approx(case.accuracy_final)
+    assert result.anytime_accuracy_all_avg == approx(case.anytime_accuracy_all_avg)
+    assert result.ttt.accuracy() == approx(case.ttt_accuracy)


### PR DESCRIPTION
Update the ocl module to match the proposed structure change in #237.

![image](https://github.com/user-attachments/assets/c6ff467e-01d7-4b60-979c-4570dd4dcaae)

Presently there are no builtin ocl specific classifiers. I'm not sure where these should go: `from capymoa.ocl.classifer import ER` or `from capymoa.ocl import ER`.
