### PR TITLE
fix: various document building bugs: cross-drive links, links to external libs and Sphinx not respecting venv

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,13 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import os
+import sys
 from pathlib import Path
 from capymoa.__about__ import __version__
 from docs.util.github_link import make_linkcode_resolve
+
+# Any subprocesses created during document building should use the same python environment
+os.environ["PYTHONEXECUTABLE"] = sys.executable
 
 discord_link = "https://discord.gg/spd2gQJGAb"
 contact_email = "heitor.gomes@vuw.ac.nz"

--- a/docs/util/github_link.py
+++ b/docs/util/github_link.py
@@ -4,8 +4,8 @@ https://github.com/scikit-learn/scikit-learn/blob/8721245511de2f225ff5f9aa5f5fad
 
 import inspect
 import os
-import subprocess
 import sys
+import subprocess
 from functools import partial
 from operator import attrgetter
 
@@ -67,18 +67,18 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         return
 
     try:
-        fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
-    except:
-        # In some circumstances, you may get an error while building docs
-        # if components cross drives (I.e., C:/ and D:/)
-        # We need to use absolute paths in that case
-        abspath = os.path.abspath(fn)
-        fn = abspath[abspath.find('capymoa')+8:].replace('\\', '/')
-
-    try:
         lineno = inspect.getsourcelines(obj)[1]
     except Exception:
-        lineno = ""
+        # Those without line numbers are external libraries whose links aren't needed
+        return
+
+    try:
+        fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
+    except Exception:
+        # In some circumstances, you may get an error while building docs
+        # if components cross drives (I.e., C:/ and D:/)
+        return
+
     return url_fmt.format(revision=revision, package=package, path=fn, lineno=lineno)
 
 


### PR DESCRIPTION
Hi team,

I've recently started looking into CapyMoa and have it ready to go in dev/doc fashion.
In attempting to generate the docs via `invoke docs.build`, I received the following error:

- reading sources... [ 85%] api/modules/capymoa.stream.preprocessing.PipelineElement
- Extension error (sphinx.ext.linkcode):
- Handler <function doctree_read at 0x00000157D32A6160> for event 'doctree-read' threw an exception (exception: path is on mount 'C:', start on mount 'D:')

After a bit of digging, I found that the `_linkcode_resolve` function within `docs/util/github_link.py` attempts to generate a relative path between drives under certain conditions. Changing this to an absolute path appears to solve the issue, and my docs were able to successfully generate. I don't see how this change would negatively impact anything and I have run all tests via `pytest` and no warnings look relevant to this change.

=========== test session starts =========== 
platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: D:\Dev\Projects\CapyMOA
configfile: pyproject.toml
testpaths: tests, src
plugins: anyio-4.11.0, nbmake-1.5.5, subtests-0.15.0, xdist-3.8.0
collected 151 items 

...

=========== warnings summary ===========
tests/ocl/test_datasets.py::test_ocl_split_datamodule_constructors[TinySplitMNIST]
  C:\Program Files\Python313\Lib\shutil.py:1281: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    tarobj.extractall(extract_dir, filter=filter)

tests/test_misc.py::test_legacy_save_load_model
  D:\Dev\Projects\CapyMOA\tests\test_misc.py:21: DeprecationWarning: Call to deprecated function (or staticmethod) legacy_save_model. (Use ``save_model(...)`` instead.) -- Deprecated since version v0.8.2.
    legacy_save_model(learner, filename)

tests/test_misc.py::test_legacy_save_load_model
  D:\Dev\Projects\CapyMOA\tests\test_misc.py:27: DeprecationWarning: Call to deprecated function (or staticmethod) legacy_load_model. (Use ``load_model(...)`` instead.) -- Deprecated since version v0.8.2.
    legacy_load_model(filename)

tests/test_regressors.py::test_regressor[PassiveAggressiveRegressor]
tests/test_regressors.py::test_regressor[SGDRegressor]
tests/test_regressors.py::test_none_predict
  D:\Dev\Projects\CapyMOA\src\capymoa\evaluation\evaluation.py:348: UserWarning: The learner did not produce a prediction for this instance
    warnings.warn("The learner did not produce a prediction for this instance")

===========130 passed, 21 skipped, 6 warnings, 24 subtests passed in 264.51s (0:04:24) ===========

Hopefully this is the right way to submit things to you - let me know if you'd prefer I open an issue first, or if I missed some step.

Cheers,
Kim