### PR TITLE
fix: update anomaly score retrieval in MOAAnomalyDetector

### DIFF
--- a/src/capymoa/base/_base.py
+++ b/src/capymoa/base/_base.py
@@ -224,10 +224,12 @@ class MOAAnomalyDetector(AnomalyDetector):
         )
 
     def score_instance(self, instance):
-        # We assume that the anomaly score is the second element of the prediction array.
-        # However, if it is not the case for a MOA learner, this method should be overridden.
-        prediction_array = self.moa_learner.getVotesForInstance(instance.java_instance)
-        return float(prediction_array[1])
+        # Get the anomaly score from the MOA learner
+        # We assume that the MOA learner has a method getAnomalyScore
+        # We convert it to float for consistency
+
+        s = self.moa_learner.getAnomalyScore(instance.java_instance.getData())
+        return float(s)
 
 
 ##############################################################


### PR DESCRIPTION
The anomaly detectors in MOA have a function called getAnomalyScore inherited from OneClassClassifier. This function should be better than getVotesForInstance because we don't need to assume that the second element of the votes array represents an anomaly score.