### PR TITLE
feat: direct download csv from datasets api

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,7 @@ extensions = [
 ]
 
 nitpick_ignore_regex = [
-    ("py:class", r".*\._[\w_]*"),  # Ignore private classes from nitpick errors
-    ("py:obj", r".*\._[\w_]*"),  # Ignore private objects from nitpick errors
+    (r"py:(class|obj)", r"(.*\.)?_[\w_]*"),  # Ignore private objects
     ("py:class", r"abc\..*"),
     ("py:class", r"com\..*"),
     ("py:class", r"java\..*"),

--- a/src/capymoa/datasets/_datasets.py
+++ b/src/capymoa/datasets/_datasets.py
@@ -1,9 +1,4 @@
 from capymoa.datasets._downloader import _DownloadableARFF
-from ._source_list import SOURCE_LIST
-
-
-def _get_remote_url(source_name: str):
-    return SOURCE_LIST[source_name].arff
 
 
 class Sensor(_DownloadableARFF):
@@ -22,7 +17,7 @@ class Sensor(_DownloadableARFF):
     #.  https://www.cse.fau.edu/~xqzhu/stream.html
     """
 
-    _url = _get_remote_url("Sensor")
+    _target_type = "categorical"
     _length = 2219803
 
 
@@ -42,7 +37,7 @@ class Hyper100k(_DownloadableARFF):
 
     # TODO: Add docstring describing the dataset and link to the original source
 
-    _url = _get_remote_url("Hyper100k")
+    _target_type = "categorical"
     _length = 100_000
 
 
@@ -79,7 +74,7 @@ class CovtFD(_DownloadableARFF):
     * :class:`CovtypeTiny` - A truncated version of the classic covertype dataset
     """
 
-    _url = _get_remote_url("CovtFD")
+    _target_type = "categorical"
     _length = 581_011
 
 
@@ -107,7 +102,7 @@ class Covtype(_DownloadableARFF):
     * :class:`CovtypeTiny` - A truncated version of the classic covertype dataset
     """
 
-    _url = _get_remote_url("Covtype")
+    _target_type = "categorical"
     _length = 581_012
 
 
@@ -137,7 +132,7 @@ class CovtypeTiny(_DownloadableARFF):
     * :class:`CovtypeNorm` - A normalized version of the classic covertype dataset
     """
 
-    _url = _get_remote_url("CovtypeTiny")
+    _target_type = "categorical"
     _length = 1001
 
 
@@ -166,7 +161,7 @@ class CovtypeNorm(_DownloadableARFF):
     * :class:`CovtypeTiny` - A truncated version of the classic covertype dataset
     """
 
-    _url = _get_remote_url("CovtypeNorm")
+    _target_type = "categorical"
     _length = 581_012
 
 
@@ -192,7 +187,7 @@ class RBFm_100k(_DownloadableARFF):
     with varying densities. Only numeric attributes are generated.
     """
 
-    _url = _get_remote_url("RBFm_100k")
+    _target_type = "categorical"
     _length = 100_000
 
 
@@ -222,7 +217,7 @@ class RTG_2abrupt(_DownloadableARFF):
     See also :class:`capymoa.stream.generator.RandomTreeGenerator`
     """
 
-    _url = _get_remote_url("RTG_2abrupt")
+    _target_type = "categorical"
     _length = 100_000
 
 
@@ -250,7 +245,7 @@ class Electricity(_DownloadableARFF):
 
     """
 
-    _url = _get_remote_url("Electricity")
+    _target_type = "categorical"
     _length = 45_312
 
 
@@ -264,7 +259,7 @@ class ElectricityTiny(_DownloadableARFF):
     See :class:`Electricity` for the widely used electricity dataset.
     """
 
-    _url = _get_remote_url("ElectricityTiny")
+    _target_type = "categorical"
     _length = 2_000
 
 
@@ -284,7 +279,7 @@ class Fried(_DownloadableARFF):
         annals of statistics 19, no. 1 (1991): 1-67.
     """
 
-    _url = _get_remote_url("Fried")
+    _target_type = "numeric"
     _length = 40_768
 
 
@@ -297,7 +292,7 @@ class FriedTiny(_DownloadableARFF):
     See :class:`Fried` for the full Friedman dataset.
     """
 
-    _url = _get_remote_url("FriedTiny")
+    _target_type = "numeric"
     _length = 1_000
 
 
@@ -317,5 +312,5 @@ class Bike(_DownloadableARFF):
     and background knowledge." Progress in Artificial Intelligence 2 (2014): 113-127.
     """
 
-    _url = _get_remote_url("Bike")
+    _target_type = "numeric"
     _length = 17_379

--- a/src/capymoa/datasets/_downloader.py
+++ b/src/capymoa/datasets/_downloader.py
@@ -1,16 +1,33 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Union
+from typing import Literal, Optional, Union
 
 from capymoa.stream._stream import Schema
-from moa.streams import ArffFileStream, InstanceStream
+from moa.streams import InstanceStream
 
-from capymoa.stream import MOAStream
+from capymoa.stream import Stream, stream_from_file
 from capymoa.datasets._utils import (
     download_unpacked,
     get_download_dir,
     infer_unpacked_path,
 )
+from capymoa.datasets._source_list import SOURCE_LIST
+
+
+FileType = Literal["arff", "csv"]
+
+
+def _resolve_dataset_url(dataset_name: str, file_type: FileType) -> str:
+    source = SOURCE_LIST[dataset_name]
+
+    if file_type == "arff":
+        return source.arff
+    if file_type == "csv":
+        if source.csv is None:
+            raise ValueError(f"Dataset {dataset_name} does not provide a CSV download.")
+        return source.csv
+
+    raise ValueError(f"Unsupported dataset file type: {file_type}")
 
 
 class _DownloadableDataset(ABC):
@@ -23,7 +40,10 @@ class _DownloadableDataset(ABC):
         self,
         directory: Union[str, Path] = get_download_dir(),
         auto_download: bool = True,
+        file_type: FileType = "arff",
     ):
+        self.file_type: FileType = file_type
+        self._url = _resolve_dataset_url(type(self).__name__, file_type)
         self.path = infer_unpacked_path(self._url, directory)
         if not self.path.exists():
             if auto_download:
@@ -36,7 +56,7 @@ class _DownloadableDataset(ABC):
 
     @classmethod
     @abstractmethod
-    def to_stream(cls, path: Path) -> InstanceStream:
+    def to_stream(cls, path: Path) -> Stream:
         """Convert the downloaded and unpacked dataset into a datastream."""
 
     def __len__(self) -> int:
@@ -46,23 +66,49 @@ class _DownloadableDataset(ABC):
         return type(self).__name__
 
 
-class _DownloadableARFF(_DownloadableDataset, MOAStream):
+class _DownloadableARFF(_DownloadableDataset, Stream):
     schema: Schema
+    stream: Stream
+    moa_stream: Optional[InstanceStream]
+    _target_type: Literal["numeric", "categorical"] | None = None
 
     def __init__(
         self,
         directory: Union[str, Path] = get_download_dir(),
         auto_download: bool = True,
+        file_type: FileType = "arff",
     ):
-        """Setup a stream from an ARFF file and optionally download it if missing.
+        """Setup a stream from a dataset file and optionally download it if missing.
 
         :param directory: Where downloads are stored.
             Defaults to :func:`capymoa.datasets.get_download_dir`.
         :param auto_download: Download the dataset if it is missing.
+        :param file_type: Download either the ``"arff"`` or ``"csv"`` dataset asset.
         """
-        _DownloadableDataset.__init__(self, directory, auto_download)
-        MOAStream.__init__(self, self.to_stream(self.path))
+        _DownloadableDataset.__init__(self, directory, auto_download, file_type)
+        self.stream = self.to_stream(self.path)
+        self.schema = self.stream.get_schema()
+        self.moa_stream = self.stream.get_moa_stream()
 
     @classmethod
-    def to_stream(cls, path: Path) -> InstanceStream:
-        return ArffFileStream(path.as_posix(), -1)
+    def to_stream(cls, path: Path) -> Stream:
+        return stream_from_file(
+            path,
+            dataset_name=cls.__name__,
+            target_type=cls._target_type,
+        )
+
+    def has_more_instances(self) -> bool:
+        return self.stream.has_more_instances()
+
+    def next_instance(self):
+        return self.stream.next_instance()
+
+    def get_schema(self) -> Schema:
+        return self.schema
+
+    def get_moa_stream(self) -> Optional[InstanceStream]:
+        return self.moa_stream
+
+    def restart(self):
+        self.stream.restart()

--- a/src/capymoa/datasets/_downloader.py
+++ b/src/capymoa/datasets/_downloader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Literal, Optional, Union
 
 from capymoa.stream._stream import Schema
-from moa.streams import InstanceStream
+from moa.streams import InstanceStream as _InstanceStream
 
 from capymoa.stream import Stream, stream_from_file
 from capymoa.datasets._utils import (
@@ -69,7 +69,7 @@ class _DownloadableDataset(ABC):
 class _DownloadableARFF(_DownloadableDataset, Stream):
     schema: Schema
     stream: Stream
-    moa_stream: Optional[InstanceStream]
+    moa_stream: Optional[_InstanceStream]
     _target_type: Literal["numeric", "categorical"] | None = None
 
     def __init__(
@@ -107,7 +107,7 @@ class _DownloadableARFF(_DownloadableDataset, Stream):
     def get_schema(self) -> Schema:
         return self.schema
 
-    def get_moa_stream(self) -> Optional[InstanceStream]:
+    def get_moa_stream(self) -> Optional[_InstanceStream]:
         return self.moa_stream
 
     def restart(self):

--- a/src/capymoa/stream/_stream_from_file.py
+++ b/src/capymoa/stream/_stream_from_file.py
@@ -82,6 +82,7 @@ def stream_from_file(
     elif filename.suffix == ".csv":
         # Read CSV file
         df = pd.read_csv(filename, na_values=["?", "NA", "NaN"])
+        df.columns = [str(column).strip() for column in df.columns]
         target = df.columns[class_index]
         categories = {}
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,6 @@
 from typing import Sized, Type
 import capymoa.datasets as capymoa_datasets
+from capymoa.stream import Stream
 from capymoa.datasets import ElectricityTiny
 from tempfile import TemporaryDirectory
 import pytest
@@ -59,13 +60,58 @@ def test_electricity_tiny_schema():
 @pytest.mark.parametrize("dataset_type", _ALL_DOWNLOADABLE_DATASET)
 def test_all_datasets(dataset_type: Type[_DownloadableDataset]):
     with TemporaryDirectory() as tmp_dir:
-        dataset = dataset_type(directory=tmp_dir)
+        dataset_arff = dataset_type(directory=tmp_dir)
+        assert isinstance(dataset_arff, Stream)
 
         i = 0
-        while dataset.has_more_instances():
-            dataset.next_instance()
+        while dataset_arff.has_more_instances():
+            dataset_arff.next_instance()
             i += 1
 
-        assert str(dataset)
-        assert isinstance(dataset, Sized), "Dataset must be an instance of Sized"
-        assert len(dataset) == i, "Dataset length must be correct"
+        assert str(dataset_arff)
+        assert isinstance(dataset_arff, Sized), "Dataset must be an instance of Sized"
+        assert len(dataset_arff) == i, "Dataset length must be correct"
+        dataset_arff.restart()
+
+        try:
+            dataset_csv = dataset_type(directory=tmp_dir, file_type="csv")
+            assert isinstance(dataset_csv, Stream)
+        except ValueError:
+            return  # If the dataset does not support CSV, skip the rest of the test
+
+        # Both should return a schema object
+        assert dataset_arff.get_schema() is not None
+        assert dataset_csv.get_schema() is not None
+
+        i = 0
+        while dataset_arff.has_more_instances() and dataset_csv.has_more_instances():
+            instance_arff = dataset_arff.next_instance()
+            instance_csv = dataset_csv.next_instance()
+
+            assert instance_arff.x == pytest.approx(instance_csv.x)
+            if dataset_csv.get_schema().is_classification():
+                assert instance_arff.y_index == pytest.approx(instance_csv.y_index)
+            elif dataset_csv.get_schema().is_regression():
+                assert instance_arff.y_value == pytest.approx(instance_csv.y_value)
+
+            i += 1
+
+        # Both datasets should be exhausted by now.
+        assert not dataset_arff.has_more_instances()
+        assert not dataset_csv.has_more_instances()
+
+        # The datasets should be restartable.
+        dataset_arff.restart()
+        dataset_csv.restart()
+
+        # After restarting, the datasets should have more instances.
+        assert dataset_arff.has_more_instances()
+        assert dataset_csv.has_more_instances()
+
+        # The string representation of the datasets should not throw an error
+        assert str(dataset_arff)
+        assert str(dataset_csv)
+        # The datasets should be the same length, and should have a size.
+        assert isinstance(dataset_arff, Sized)
+        assert isinstance(dataset_csv, Sized)
+        assert len(dataset_arff) == len(dataset_csv) == i


### PR DESCRIPTION
## Add CSV Support to Built-in Datasets API

This PR adds CSV support to the built-in Datasets API while preserving the current default behaviour.

After this change, built-in datasets still download ARFF by default, but can now also download and open CSV files when available:

```python
from capymoa.datasets import Hyper100k

stream_arff = Hyper100k()
stream_csv = Hyper100k(file_type="csv")
```

## Why

CapyMOA already stores CSV source URLs for several datasets in `_source_list.py`, but the public Datasets API only used the ARFF sources.

This made it harder to:

- Benchmark CapyMOA datasets with non-MOA workflows  
- Reuse hosted datasets with other tooling  
- Validate CSV dataset assets through the public API  

This PR exposes that capability in a simple way without changing the existing ARFF default.

## What Changed

- Added `file_type="arff" | "csv"` support to the shared dataset download logic  
- Kept ARFF as the default for backward compatibility  
- Made built-in dataset classes use shared URL resolution instead of hardcoding ARFF URLs  
- Routed downloaded dataset files through the appropriate stream loader based on file type  
- Preserved task semantics for CSV-backed datasets by explicitly marking built-in datasets as classification or regression  
- Normalised CSV headers when loading from file so headers with extra whitespace do not break target detection  

## Behaviour

Default behaviour is unchanged:

```python
from capymoa.datasets import ElectricityTiny

stream = ElectricityTiny()
```

CSV can now be requested explicitly:

```python
from capymoa.datasets import ElectricityTiny, Hyper100k

stream1 = ElectricityTiny(file_type="csv")
stream2 = Hyper100k(file_type="csv")
```

## Notes

- ARFF-backed datasets continue to use the MOA-backed path  
- CSV-backed datasets use the Python stream path  
- For CSV-backed evaluation, `optimise=False` may be required because these streams are not MOA-backed  

## Validation

Small test of the CSV-backed built-in datasets with representative classification and regression cases.

### Examples tested

- `ElectricityTiny(file_type="csv")`  
- `FriedTiny(file_type="csv")`  
- `Hyper100k(file_type="csv")`  

Also ran a small end-to-end evaluation on:

```python
Hyper100k(file_type="csv")
```

with `PassiveAggressiveClassifier` using:

```python
prequential_evaluation(..., max_instances=100, optimise=False)
```

## Example Test

```python
from pathlib import Path

from capymoa.classifier import HoeffdingTree
from capymoa.datasets import (
    Bike,
    CovtFD,
    Covtype,
    CovtypeNorm,
    CovtypeTiny,
    Electricity,
    ElectricityTiny,
    Fried,
    FriedTiny,
    Hyper100k,
    RBFm_100k,
    RTG_2abrupt,
    Sensor,
)
from capymoa.evaluation import prequential_evaluation
from capymoa.regressor import FIMTDD


MAX_INSTANCES = 100
DOWNLOAD_DIR = Path("data")

DATASETS = [
    Sensor,
    Hyper100k,
    CovtFD,
    Covtype,
    CovtypeTiny,
    CovtypeNorm,
    RBFm_100k,
    RTG_2abrupt,
    ElectricityTiny,
    Electricity,
    Fried,
    FriedTiny,
    Bike,
]


def build_learner(stream):
    schema = stream.get_schema()
    if schema.is_classification():
        return HoeffdingTree(schema=schema)
    return FIMTDD(schema=schema)


def main():
    DOWNLOAD_DIR.mkdir(exist_ok=True)

    for dataset_cls in DATASETS:
        print(f"\n=== Testing {dataset_cls.__name__} (csv) ===")

        try:
            stream = dataset_cls(directory=DOWNLOAD_DIR, file_type="csv")
            learner = build_learner(stream)

            print(f"path: {stream.path}")
            print(f"task: {'classification' if stream.get_schema().is_classification() else 'regression'}")
            print(f"learner: {learner}")

            results = prequential_evaluation(
                stream=stream,
                learner=learner,
                max_instances=MAX_INSTANCES,
                progress_bar=False,
                optimise=False,
            )

            if stream.get_schema().is_classification():
                print(f"accuracy: {results.cumulative.accuracy():.4f}")
            else:
                print(f"rmse: {results.cumulative.rmse():.4f}")

            print("status: OK")

        except Exception as exc:
            print("status: FAIL")
            print(f"error: {type(exc).__name__}: {exc}")


if __name__ == "__main__":
    main()
```