### PR TITLE
feat(drift): add ``from_cli`` constructor and add docs

### DIFF
--- a/src/capymoa/_cli.py
+++ b/src/capymoa/_cli.py
@@ -1,0 +1,121 @@
+"""Internal functions for generating CLI creation strings for MOA objects."""
+
+from capymoa.base import MOAClassifier, MOARegressor, MOAPredictionIntervalLearner
+from capymoa.drift.base_detector import MOADriftDetector
+from capymoa.stream import MOAStream
+
+from moa.streams import InstanceStream as _InstanceStream
+from moa.options import AbstractOptionHandler as _AbstractOptionHandler
+from moa.classifiers import AbstractClassifier as _AbstractClassifier
+from moa.classifiers import Regressor as _AbstractRegressor
+from moa.classifiers.core.driftdetection import (
+    AbstractChangeDetector as _AbstractChangeDetector,
+)
+from moa.classifiers.predictioninterval import (
+    PredictionIntervalLearner as _PredictionIntervalLearner,
+)
+from typing import Type
+
+
+def cli_str(object: _AbstractOptionHandler, type_: Type[_AbstractOptionHandler]) -> str:
+    """Return a CLI string for creating MOA objects.
+
+    >>> from moa.classifiers.trees import HoeffdingTree
+    >>> from moa.classifiers import AbstractClassifier
+    >>> cli_str(HoeffdingTree(), AbstractClassifier)
+    '(trees.HoeffdingTree)'
+
+    :param object: MOA object to generate CLI string for.
+    :param type_: Type of the MOA object, used to strip the fully qualified name to be
+        more concise.
+    :return: CLI string for creating the MOA object.
+    """
+    return f"({str(object.getCLICreationString(type_)).strip()})"
+
+
+def cli_str_classifier(classifier: _AbstractClassifier | MOAClassifier) -> str:
+    """Return a CLI string for creating a MOA classifier.
+
+    >>> from moa.classifiers.trees import HoeffdingTree
+    >>> cli_str_classifier(HoeffdingTree())
+    '(trees.HoeffdingTree)'
+
+    """
+    if isinstance(classifier, MOAClassifier):
+        return cli_str(classifier.moa_learner, _AbstractClassifier)
+    elif isinstance(classifier, _AbstractClassifier):
+        return cli_str(classifier, _AbstractClassifier)
+    else:
+        raise ValueError("Unknown Type")
+
+
+def cli_str_regressor(regressor: _AbstractRegressor | MOARegressor) -> str:
+    """Return a CLI string for creating a MOA regressor.
+
+    >>> from moa.classifiers.trees import HoeffdingTree
+    >>> cli_str_regressor(HoeffdingTree())
+    '(trees.HoeffdingTree)'
+
+    """
+    if isinstance(regressor, MOARegressor):
+        # TODO: type ignore should be removed if regressor.moa_learner is properly typed
+        return cli_str(regressor.moa_learner, _AbstractRegressor)  # type: ignore
+    elif isinstance(regressor, _AbstractRegressor):
+        return cli_str(regressor, _AbstractRegressor)  # type: ignore
+    elif isinstance(regressor, (_AbstractClassifier, MOAClassifier)):
+        # Some regressor are just classifiers.
+        return cli_str_classifier(regressor)
+    else:
+        raise ValueError("Unknown Type")
+
+
+def cli_str_drift_detector(
+    detector: _AbstractChangeDetector | MOADriftDetector,
+) -> str:
+    """Return a CLI string for creating a MOA drift detector.
+
+    >>> from moa.classifiers.core.driftdetection import ADWINChangeDetector
+    >>> cli_str_drift_detector(ADWINChangeDetector())
+    '(ADWINChangeDetector)'
+
+    """
+    if isinstance(detector, MOADriftDetector):
+        return cli_str(detector.moa_detector, _AbstractChangeDetector)
+    elif isinstance(detector, _AbstractChangeDetector):
+        return cli_str(detector, _AbstractChangeDetector)
+    else:
+        raise ValueError("Unknown Type")
+
+
+def cli_str_prediction_interval(
+    predictor: _PredictionIntervalLearner | MOAPredictionIntervalLearner,
+) -> str:
+    """Return a CLI string for creating a MOA prediction interval learner.
+
+    >>> from moa.classifiers.predictioninterval import MVEPredictionInterval
+    >>> cli_str_prediction_interval(MVEPredictionInterval())
+    '(MVEPredictionInterval...
+
+    """
+    if isinstance(predictor, MOAPredictionIntervalLearner):
+        return cli_str(predictor.moa_learner, _PredictionIntervalLearner)  # type: ignore
+    elif isinstance(predictor, _PredictionIntervalLearner):
+        return cli_str(predictor, _PredictionIntervalLearner)
+    else:
+        raise ValueError("Unknown Type")
+
+
+def cli_str_stream(stream: MOAStream | _InstanceStream) -> str:
+    """Return a CLI string for creating a MOA stream.
+
+    >>> from moa.streams.generators import RandomRBFGenerator
+    >>> cli_str_stream(RandomRBFGenerator())
+    '(generators.RandomRBFGenerator)'
+
+    """
+    if isinstance(stream, MOAStream):
+        return cli_str(stream.moa_stream, _InstanceStream)
+    elif isinstance(stream, _InstanceStream):
+        return cli_str(stream, _InstanceStream)
+    else:
+        raise ValueError("Unknown Type")

--- a/src/capymoa/_utils.py
+++ b/src/capymoa/_utils.py
@@ -94,29 +94,6 @@ def build_cli_str_from_mapping_and_locals(mapping: Dict[str, str], lcs: Dict[str
     return config_str
 
 
-def _get_moa_creation_CLI(moa_object):
-    """Returns the MOA CLI string for a given MOA object.
-
-    >>> from moa.streams import ConceptDriftStream
-    ...
-    >>> stream = ConceptDriftStream()
-    >>> _get_moa_creation_CLI(stream)
-    'streams.ConceptDriftStream'
-    """
-
-    moa_class_id = str(moa_object.getClass().getName())
-    moa_class_id_parts = moa_class_id.split(".")
-    moa_stream_str = f"{moa_class_id_parts[-2]}.{moa_class_id_parts[-1]}"
-
-    moa_cli_creation = str(moa_object.getCLICreationString(moa_object.__class__))
-    CLI = moa_cli_creation.split(" ", 1)
-
-    if len(CLI) > 1 and len(CLI[1]) > 1:
-        moa_stream_str = f"({moa_stream_str} {CLI[1]})"
-
-    return moa_stream_str
-
-
 def _leaf_prediction(leaf_prediction):
     """Checks the leaf_prediction option. Internal method used to check leaf_prediction parameters.
 

--- a/src/capymoa/base/__init__.py
+++ b/src/capymoa/base/__init__.py
@@ -6,8 +6,6 @@ from capymoa.base._base import (
     MOAClusterer,
     MOAPredictionIntervalLearner,
     PredictionIntervalLearner,
-    _extract_moa_drift_detector_CLI,
-    _extract_moa_learner_CLI,
 )
 from capymoa.base._classifier import (
     BatchClassifier,
@@ -23,8 +21,6 @@ from capymoa.base._ssl import (
 from ._batch import Batch
 
 __all__ = [
-    "_extract_moa_drift_detector_CLI",
-    "_extract_moa_learner_CLI",
     "Classifier",
     "Batch",
     "BatchClassifier",

--- a/src/capymoa/base/_base.py
+++ b/src/capymoa/base/_base.py
@@ -2,123 +2,12 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from jpype import _jpype
-from moa.classifiers import (
-    Classifier as MOA_Classifier_Interface,
-)
-from moa.classifiers import (
-    Regressor as MOA_Regressor_Interface,
-)
-from moa.classifiers.predictioninterval import (
-    PredictionIntervalLearner as MOA_PredictionInterval_Interface,
-)
-from moa.classifiers.trees import (
-    ARFFIMTDD as MOA_ARFFIMTDD,
-)
-from moa.classifiers.trees import (
-    SelfOptimisingBaseTree as MOA_SOKNLBT,
-)
 from moa.core import Utils
 
-from capymoa.base._classifier import MOAClassifier
 from capymoa.base._regressor import MOARegressor, Regressor
 from capymoa.instance import Instance
 from capymoa.stream._stream import Schema
 from capymoa.type_alias import LabelIndex
-
-##############################################################
-##################### INTERNAL FUNCTIONS #####################
-##############################################################
-
-
-def _extract_moa_drift_detector_CLI(drift_detector):
-    """
-    Auxiliary function to retrieve the command-line interface (CLI)
-    creation command for a MOA Drift Detector.
-
-    Parameters:
-    - drift_detector: The drift detector class for which the CLI command is needed
-
-    Returns:
-    A string representing the CLI command for creating a Drift Detector.
-    """
-
-    CLI = drift_detector.CLI
-
-    moa_detector = drift_detector.moa_detector
-    moa_detector_class_id = str(moa_detector.getClass().getName())
-    moa_detector_class_id_parts = moa_detector_class_id.split(".")
-
-    moa_detector_str = f"{moa_detector_class_id_parts[-1]}"
-    moa_detector_str = f"({moa_detector_str} {CLI})"
-
-    return moa_detector_str
-
-
-def _get_moa_creation_CLI(moa_learner):
-    """
-    Auxiliary function to retrieve the command-line interface (CLI)
-    creation command for a MOA learner.
-
-    Parameters:
-    - moa_learner: The MOA learner for which the CLI command is needed,
-    it must be a MOA learner object
-
-    Returns:
-    A string representing the CLI command for creating the MOA learner.
-    """
-    moa_learner_class_id = str(moa_learner.getClass().getName())
-    moa_learner_class_id_parts = moa_learner_class_id.split(".")
-
-    moa_learner_str = (
-        f"{moa_learner_class_id_parts[-1]}"
-        if isinstance(moa_learner, MOA_ARFFIMTDD)
-        or isinstance(moa_learner, MOA_SOKNLBT)
-        else f"{moa_learner_class_id_parts[-2]}.{moa_learner_class_id_parts[-1]}"
-    )
-
-    moa_cli_creation = str(moa_learner.getCLICreationString(moa_learner.__class__))
-    CLI = moa_cli_creation.split(" ", 1)
-
-    if len(CLI) > 1 and len(CLI[1]) > 1:
-        moa_learner_str = f"({moa_learner_str} {CLI[1]})"
-
-    return moa_learner_str
-
-
-def _extract_moa_learner_CLI(learner):
-    """
-    Auxiliary function to extract the command-line interface (CLI)
-    from a MOA learner object or a MOA learner class or even a
-    MOAClassifier object (which has a moa_learner internally).
-
-    Parameters:
-    - moa_learner: The object or class representing the MOA learner
-
-    Returns:
-    A string representing the CLI command for creating the MOA learner.
-    """
-
-    # Check if the base_learner is a MOAClassifie or a MOARegressor
-    if (
-        isinstance(learner, MOAClassifier)
-        or isinstance(learner, MOARegressor)
-        or isinstance(learner, MOAPredictionIntervalLearner)
-    ):
-        learner = _get_moa_creation_CLI(learner.moa_learner)
-
-    # ... or a Classifier or a Regressor (Interfaces from MOA) type
-    if (
-        isinstance(learner, MOA_Classifier_Interface)
-        or isinstance(learner, MOA_Regressor_Interface)
-        or isinstance(learner, MOA_PredictionInterval_Interface)
-    ):
-        learner = _get_moa_creation_CLI(learner)
-
-    # ... or a java object, which we presume is a MOA object (if it is not, MOA will raise the error)
-    if isinstance(learner, _jpype._JClass):
-        learner = _get_moa_creation_CLI(learner())
-    return learner
-
 
 ##############################################################
 ######################### REGRESSORS #########################

--- a/src/capymoa/classifier/_adaptive_random_forest.py
+++ b/src/capymoa/classifier/_adaptive_random_forest.py
@@ -1,15 +1,9 @@
 from typing import Optional
-from capymoa.base import (
-    MOAClassifier,
-    _extract_moa_learner_CLI,
-    _extract_moa_drift_detector_CLI,
-)
+from capymoa.base import MOAClassifier
+from capymoa._cli import cli_str_drift_detector, cli_str_classifier
 
-from capymoa.base._classifier import Classifier
-from capymoa.drift.base_detector import BaseDriftDetector
-from capymoa.drift.detectors import (
-    ADWIN,
-)
+from capymoa.drift.base_detector import MOADriftDetector
+from capymoa.drift.detectors import ADWIN
 
 from capymoa.stream._stream import Schema
 from moa.classifiers.meta import AdaptiveRandomForest as _MOA_AdaptiveRandomForest
@@ -51,14 +45,14 @@ class AdaptiveRandomForestClassifier(MOAClassifier):
         schema: Optional[Schema] = None,
         CLI: Optional[str] = None,
         random_seed: int = 1,
-        base_learner: Optional[Classifier] = None,
+        base_learner: Optional[MOAClassifier] = None,
         ensemble_size: int = 100,
         max_features: float = 0.6,
         lambda_param: float = 6.0,
         minibatch_size: Optional[int] = None,
         number_of_jobs: int = 1,
-        drift_detection_method: Optional[BaseDriftDetector] = None,
-        warning_detection_method: Optional[BaseDriftDetector] = None,
+        drift_detection_method: Optional[MOADriftDetector] = None,
+        warning_detection_method: Optional[MOADriftDetector] = None,
         disable_weighted_vote: bool = False,
         disable_drift_detection: bool = False,
         disable_background_learner: bool = False,
@@ -97,7 +91,7 @@ class AdaptiveRandomForestClassifier(MOAClassifier):
             self.base_learner = (
                 "(ARFHoeffdingTree -e 2000000 -g 50 -c 0.01)"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.base_learner = self.base_learner.replace("trees.", "")
             self.ensemble_size = ensemble_size
@@ -123,16 +117,15 @@ class AdaptiveRandomForestClassifier(MOAClassifier):
                     "square root of total features."
                 )
 
+            if drift_detection_method is None:
+                drift_detection_method = ADWIN(delta=0.001)
+            if warning_detection_method is None:
+                warning_detection_method = ADWIN(delta=0.01)
+
             self.lambda_param = lambda_param
-            self.drift_detection_method = (
-                _extract_moa_drift_detector_CLI(ADWIN(delta=0.001))
-                if drift_detection_method is None
-                else _extract_moa_drift_detector_CLI(drift_detection_method)
-            )
-            self.warning_detection_method = (
-                _extract_moa_drift_detector_CLI(ADWIN(delta=0.01))
-                if warning_detection_method is None
-                else _extract_moa_drift_detector_CLI(warning_detection_method)
+            self.drift_detection_method = cli_str_drift_detector(drift_detection_method)
+            self.warning_detection_method = cli_str_drift_detector(
+                warning_detection_method
             )
             self.disable_weighted_vote = disable_weighted_vote
             self.disable_drift_detection = disable_drift_detection

--- a/src/capymoa/classifier/_leveraging_bagging.py
+++ b/src/capymoa/classifier/_leveraging_bagging.py
@@ -1,7 +1,7 @@
 from capymoa.base import (
     MOAClassifier,
-    _extract_moa_learner_CLI,
 )
+from capymoa._cli import cli_str_classifier
 
 from moa.classifiers.meta import LeveragingBag as _MOA_LeveragingBag
 from moa.classifiers.meta.minibatch import LeveragingBagMB as _MOA_LeveragingBagMB
@@ -62,7 +62,7 @@ class LeveragingBagging(MOAClassifier):
             self.base_learner = (
                 "trees.HoeffdingTree"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.ensemble_size = ensemble_size
             CLI = f"-l {self.base_learner} -s {self.ensemble_size}"
@@ -70,7 +70,7 @@ class LeveragingBagging(MOAClassifier):
             self.base_learner = (
                 "trees.HoeffdingTree"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.ensemble_size = ensemble_size
             moa_learner = None

--- a/src/capymoa/classifier/_online_adwin_bagging.py
+++ b/src/capymoa/classifier/_online_adwin_bagging.py
@@ -1,7 +1,7 @@
 from capymoa.base import (
     MOAClassifier,
-    _extract_moa_learner_CLI,
 )
+from capymoa._cli import cli_str_classifier
 
 from moa.classifiers.meta import OzaBagAdwin as _MOA_OzaBagAdwin
 from moa.classifiers.meta.minibatch import OzaBagAdwinMB as _MOA_OzaBagAdwinMB
@@ -89,7 +89,7 @@ class OnlineAdwinBagging(MOAClassifier):
             self.base_learner = (
                 "trees.HoeffdingTree"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.ensemble_size = ensemble_size
             CLI = f"-l {self.base_learner} -s {self.ensemble_size}"
@@ -97,7 +97,7 @@ class OnlineAdwinBagging(MOAClassifier):
             self.base_learner = (
                 "trees.HoeffdingTree"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.ensemble_size = ensemble_size
             moa_learner = None

--- a/src/capymoa/classifier/_online_bagging.py
+++ b/src/capymoa/classifier/_online_bagging.py
@@ -1,7 +1,7 @@
 from capymoa.base import (
     MOAClassifier,
-    _extract_moa_learner_CLI,
 )
+from capymoa._cli import cli_str_classifier
 import os
 from moa.classifiers.meta import OzaBag as _MOA_OzaBag
 from moa.classifiers.meta.minibatch import OzaBagMB as _MOA_OzaBagMB
@@ -62,7 +62,7 @@ class OnlineBagging(MOAClassifier):
             self.base_learner = (
                 "trees.HoeffdingTree"
                 if base_learner is None
-                else _extract_moa_learner_CLI(base_learner)
+                else cli_str_classifier(base_learner)
             )
             self.ensemble_size = ensemble_size
             moa_learner = None

--- a/src/capymoa/drift/base_detector.py
+++ b/src/capymoa/drift/base_detector.py
@@ -4,7 +4,6 @@ from typing_extensions import override
 from moa.classifiers.core.driftdetection import (
     AbstractChangeDetector as _AbstractChangeDetector,
 )
-from capymoa._utils import _get_moa_creation_CLI
 
 
 class BaseDriftDetector(ABC):
@@ -94,7 +93,12 @@ class MOADriftDetector(BaseDriftDetector):
         """
         if cls._moa_detector_type is None:
             raise NotImplementedError("Unset class attribute _moa_detector_type.")
-        return MOADriftDetector(cli=cli, moa_detector_type=cls._moa_detector_type)
+
+        instance = cls.__new__(cls)
+        MOADriftDetector.__init__(
+            instance, cli=cli, moa_detector_type=cls._moa_detector_type
+        )
+        return instance
 
     @override
     def add_element(self, element: float) -> None:
@@ -134,10 +138,6 @@ class MOADriftDetector(BaseDriftDetector):
 
     def cli_help(self) -> str:
         return str(self.moa_detector.getOptions().getHelpString())
-
-    @property
-    def cli(self) -> str:
-        return _get_moa_creation_CLI(self.moa_detector)
 
     def __str__(self) -> str:
         full_name = str(self.moa_detector.getClass().getCanonicalName())

--- a/src/capymoa/drift/base_detector.py
+++ b/src/capymoa/drift/base_detector.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Type
 from typing_extensions import override
-from numpy import double
-
-from jpype import _jpype
+from moa.classifiers.core.driftdetection import (
+    AbstractChangeDetector as _AbstractChangeDetector,
+)
+from capymoa._utils import _get_moa_creation_CLI
 
 
 class BaseDriftDetector(ABC):
@@ -56,45 +57,48 @@ class BaseDriftDetector(ABC):
 
 
 class MOADriftDetector(BaseDriftDetector):
-    """
-    A wrapper class for using MOA (Massive Online Analysis) drift detectors in CapyMOA.
-    """
+    """A MOA (Massive Online Analysis) drift detector for CapyMOA."""
 
-    def __init__(self, moa_detector, CLI=None):
-        """
-        :param moa_detector: The MOA detector object or class identifier.
-        :param CLI: The command-line interface (CLI) configuration for the MOA drift detector, defaults to None
-        """
+    _moa_detector_type: Type[_AbstractChangeDetector] | None = None
+
+    def __init__(
+        self,
+        cli: str = "",
+        moa_detector_type: Type[_AbstractChangeDetector] | None = None,
+    ):
+        """Initialize the wrapped MOA drift detector."""
         super().__init__()
+        # Allow passing the MOA detector type directly to the constructor, which is
+        # useful for the from_cli class method. Otherwise, use the class attribute
+        # _moa_detector_type defined in each subclass.
+        if moa_detector_type is not None:
+            self._moa_detector_type = moa_detector_type
+        if self._moa_detector_type is None:
+            raise NotImplementedError(
+                "MOA detector type not specified. Set the class attribute "
+                "_moa_detector_type or pass moa_detector_type to the constructor."
+            )
 
-        self.CLI = CLI
-
-        if isinstance(moa_detector, type):
-            if isinstance(moa_detector, _jpype._JClass):
-                moa_detector = moa_detector()
-            else:  # this is not a Java object, thus it certainly isn't a MOA learner
-                raise ValueError("Invalid MOA detector provided.")
-
-        self.moa_detector = moa_detector
-
-        # If the CLI is None, we assume the object has already been configured
-        # or that default values should be used.
-        if self.CLI is not None:
-            self.moa_detector.getOptions().setViaCLIString(CLI)
-
+        # Setup Detector
+        self.moa_detector = self._moa_detector_type()
+        self.moa_detector.getOptions().setViaCLIString(cli)
         self.moa_detector.prepareForUse()
         self.moa_detector.resetLearning()
 
-    def __str__(self):
-        full_name = str(self.moa_detector.getClass().getCanonicalName())
-        return full_name.rsplit(".", 1)[1] if "." in full_name else full_name
+    @classmethod
+    def from_cli(cls, cli: str) -> "MOADriftDetector":
+        """Create a detector instance configured from a MOA CLI string.
 
-    def cli_help(self):
-        return str(self.moa_detector.getOptions().getHelpString())
+        :param cli: Command-line style options string for MOA detector hyper-parameters.
+        :return: A new detector instance initialized with ``cli``.
+        """
+        if cls._moa_detector_type is None:
+            raise NotImplementedError("Unset class attribute _moa_detector_type.")
+        return MOADriftDetector(cli=cli, moa_detector_type=cls._moa_detector_type)
 
     @override
     def add_element(self, element: float) -> None:
-        self.moa_detector.input(double(element))
+        self.moa_detector.input(element)
         self.data.append(element)
         self.idx += 1
 
@@ -109,6 +113,7 @@ class MOADriftDetector(BaseDriftDetector):
 
     def reset(self, clean_history: bool = False) -> None:
         """Reset the drift detector.
+
         :param clean_history: Whether to reset detection history, defaults to False
         """
         self.in_concept_change = False
@@ -126,3 +131,14 @@ class MOADriftDetector(BaseDriftDetector):
     def get_params(self) -> Dict[str, Any]:
         options = list(self.moa_detector.getOptions().getOptionArray())
         return {opt.getName(): opt.getValueAsCLIString() for opt in options}
+
+    def cli_help(self) -> str:
+        return str(self.moa_detector.getOptions().getHelpString())
+
+    @property
+    def cli(self) -> str:
+        return _get_moa_creation_CLI(self.moa_detector)
+
+    def __str__(self) -> str:
+        full_name = str(self.moa_detector.getClass().getCanonicalName())
+        return full_name.rsplit(".", 1)[1] if "." in full_name else full_name

--- a/src/capymoa/drift/detectors/adwin.py
+++ b/src/capymoa/drift/detectors/adwin.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import (
@@ -38,11 +36,14 @@ class ADWIN(MOADriftDetector):
 
     """
 
-    def __init__(self, delta: float = 0.002, CLI: Optional[str] = None):
-        if CLI is None:
-            CLI = f"-a {delta}"
+    _moa_detector_type = _ADWINChangeDetector
 
-        super().__init__(moa_detector=_ADWINChangeDetector(), CLI=CLI)
+    def __init__(self, delta: float = 0.002):
+        """Create an ADWIN drift detector.
 
-        self.delta = delta
-        self.get_params()
+        :param delta: Confidence parameter used by ADWIN's change test. Smaller values
+            make the detector more conservative, while larger values make it more
+            sensitive to distribution changes. Defaults to 0.002.
+        """
+        cli = f"-a {delta}"
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/cusum.py
+++ b/src/capymoa/drift/detectors/cusum.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import CusumDM as _CusumDM
@@ -29,19 +27,23 @@ class CUSUM(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _CusumDM
+
     def __init__(
         self,
         min_n_instances: int = 30,
         delta: float = 0.005,
         lambda_: float = 50,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = f"-n {min_n_instances} -d {delta} -l {lambda_}"
+        """Create a CUSUM drift detector.
 
-        super().__init__(moa_detector=_CusumDM(), CLI=CLI)
-
-        self.min_n_instances = min_n_instances
-        self.delta = delta
-        self.lambda_ = lambda_
-        self.get_params()
+        :param min_n_instances: Minimum number of instances to observe before change
+            detection is enabled. Defaults to 30.
+        :param delta: CUSUM slack parameter subtracted from the running sum at each
+            step. Larger values make the detector less sensitive to small shifts.
+            Defaults to 0.005.
+        :param lambda_: Threshold for the cumulative sum; once the running sum exceeds
+            this value, a change is reported. Defaults to 50.
+        """
+        cli = f"-n {min_n_instances} -d {delta} -l {lambda_}"
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/ddm.py
+++ b/src/capymoa/drift/detectors/ddm.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import DDM as _DDM
@@ -36,19 +34,22 @@ class DDM(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _DDM
+
     def __init__(
         self,
         min_n_instances: int = 30,
         warning_level: float = 2.0,
         out_control_level: float = 3.0,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = f"-n {min_n_instances} -w {warning_level} -o {out_control_level}"
+        """Create a DDM drift detector.
 
-        super().__init__(moa_detector=_DDM(), CLI=CLI)
-
-        self.min_n_instances = min_n_instances
-        self.warning_level = warning_level
-        self.out_control_level = out_control_level
-        self.get_params()
+        :param min_n_instances: Minimum number of instances to observe before change
+            detection is enabled. Defaults to 30.
+        :param warning_level: Multiplier applied to the minimum error estimate for
+            entering the warning zone. Defaults to 2.0.
+        :param out_control_level: Multiplier applied to the minimum error estimate for
+            reporting a concept change. Defaults to 3.0.
+        """
+        cli = f"-n {min_n_instances} -w {warning_level} -o {out_control_level}"
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/ewma_chart.py
+++ b/src/capymoa/drift/detectors/ewma_chart.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import EWMAChartDM as _EWMAChartDM
@@ -35,14 +33,8 @@ class EWMAChart(MOADriftDetector):
 
     """
 
-    def __init__(
-        self, min_n_instances: int = 30, lambda_: float = 0.2, CLI: Optional[str] = None
-    ):
-        if CLI is None:
-            CLI = f"-n {min_n_instances} -l {lambda_} "
+    _moa_detector_type = _EWMAChartDM
 
-        super().__init__(moa_detector=_EWMAChartDM(), CLI=CLI)
-
-        self.min_n_instances = min_n_instances
-        self.lambda_ = lambda_
-        self.get_params()
+    def __init__(self, min_n_instances: int = 30, lambda_: float = 0.2):
+        cli = f"-n {min_n_instances} -l {lambda_} "
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/geometric_ma.py
+++ b/src/capymoa/drift/detectors/geometric_ma.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import (
@@ -31,19 +29,24 @@ class GeometricMovingAverage(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _GeometricMovingAverageDM
+
     def __init__(
         self,
         min_n_instances: int = 30,
         lambda_: float = 1.0,
         alpha: float = 0.99,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = f"-n {min_n_instances} -l {lambda_} -a {alpha}"
+        """Create a Geometric Moving Average drift detector.
 
-        super().__init__(moa_detector=_GeometricMovingAverageDM(), CLI=CLI)
-
-        self.min_n_instances = min_n_instances
-        self.lambda_ = lambda_
-        self.alpha = alpha
-        self.get_params()
+        :param min_n_instances: Minimum number of instances to observe before change
+            detection is enabled. Defaults to 30.
+        :param lambda_: Detection threshold for the geometric moving-average statistic;
+            higher values require stronger evidence before reporting change. Defaults to
+            1.0.
+        :param alpha: Smoothing factor for the geometric moving-average statistic.
+            Values closer to 1.0 emphasise past observations and react more slowly to
+            recent changes. Defaults to 0.99.
+        """
+        cli = f"-n {min_n_instances} -l {lambda_} -a {alpha}"
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/hddm_a.py
+++ b/src/capymoa/drift/detectors/hddm_a.py
@@ -38,6 +38,8 @@ class HDDMAverage(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _HDDM_A_Test
+
     TEST_TYPES = ["Two-sided", "One-sided"]
 
     def __init__(
@@ -66,7 +68,7 @@ class HDDMAverage(MOADriftDetector):
         if CLI is None:
             CLI = f"-d {drift_confidence} -w {warning_confidence} -t {test_type}"
 
-        super().__init__(moa_detector=_HDDM_A_Test(), CLI=CLI)
+        super().__init__(cli=CLI)
 
         self.drift_confidence = drift_confidence
         self.warning_confidence = warning_confidence

--- a/src/capymoa/drift/detectors/hddm_w.py
+++ b/src/capymoa/drift/detectors/hddm_w.py
@@ -21,7 +21,7 @@ class HDDMWeighted(MOADriftDetector):
     ...     data_stream[i] = np.random.randint(4, high=8)
     >>>
     >>> for i in range(2000):
-    ...     detector.add_element(data_stream[i])
+    ...     detector.add_element(float(data_stream[i]))
     ...     if detector.detected_change():
     ...         print("Change detected in data: " + str(data_stream[i]) + " - at index: " + str(i))
     Change detected in data: 6 - at index: 1234

--- a/src/capymoa/drift/detectors/hddm_w.py
+++ b/src/capymoa/drift/detectors/hddm_w.py
@@ -31,6 +31,8 @@ class HDDMWeighted(MOADriftDetector):
         27.3 (2014): 810-823.
     """
 
+    _moa_detector_type = _HDDM_W_Test
+
     TEST_TYPES = ["Two-sided", "One-sided"]
 
     def __init__(
@@ -67,7 +69,7 @@ class HDDMWeighted(MOADriftDetector):
                 f"-t {test_type}"
             )
 
-        super().__init__(moa_detector=_HDDM_W_Test(), CLI=CLI)
+        super().__init__(cli=CLI)
 
         self.drift_confidence = drift_confidence
         self.warning_confidence = warning_confidence

--- a/src/capymoa/drift/detectors/page_hinkley.py
+++ b/src/capymoa/drift/detectors/page_hinkley.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import PageHinkleyDM as _PageHinkleyDM
@@ -36,21 +34,27 @@ class PageHinkley(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _PageHinkleyDM
+
     def __init__(
         self,
         min_n_instances: int = 30,
         delta: float = 0.005,
         lambda_: float = 50.0,
         alpha: float = 0.9999,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = f"-n {min_n_instances} -d {delta} -l {lambda_} -a {alpha}"
+        """Create a Page-Hinkley drift detector.
 
-        super().__init__(moa_detector=_PageHinkleyDM(), CLI=CLI)
-
-        self.min_n_instances = min_n_instances
-        self.delta = delta
-        self.lambda_ = lambda_
-        self.alpha = alpha
-        self.get_params()
+        :param min_n_instances: Minimum number of instances to observe before change
+            detection is enabled. Defaults to 30.
+        :param delta: Slack term subtracted at each update of the running statistic.
+            Larger values make the detector less sensitive to small shifts. Defaults to
+            0.005.
+        :param lambda_: Detection threshold for the Page-Hinkley statistic; once
+            exceeded, a change is reported. Defaults to 50.0.
+        :param alpha: Forgetting factor applied to the previous statistic. Values closer
+            to 1.0 retain longer history and typically react more slowly to abrupt
+            changes. Defaults to 0.9999.
+        """
+        cli = f"-n {min_n_instances} -d {delta} -l {lambda_} -a {alpha}"
+        super().__init__(cli=cli)

--- a/src/capymoa/drift/detectors/rddm.py
+++ b/src/capymoa/drift/detectors/rddm.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import RDDM as _RDDM
@@ -35,6 +33,8 @@ class RDDM(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _RDDM
+
     def __init__(
         self,
         min_n_instances: int = 129,
@@ -43,24 +43,30 @@ class RDDM(MOADriftDetector):
         max_size_concept: int = 40000,
         min_size_concept: int = 7000,
         warning_limit: int = 1400,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = (
-                f"-n {min_n_instances} "
-                f"-w {warning_level} "
-                f"-o {drift_level} "
-                f"-x {max_size_concept} "
-                f"-y {min_size_concept} "
-                f"-z {warning_limit}"
-            )
+        """Create an RDDM drift detector.
 
-        super().__init__(moa_detector=_RDDM(), CLI=CLI)
+        :param min_n_instances: Minimum number of instances before the detector starts
+            monitoring for drift. Defaults to 129.
+        :param warning_level: Multiplier applied to the minimum error estimate for
+            entering the warning zone. Defaults to 1.773.
+        :param drift_level: Multiplier applied to the minimum error estimate for
+            declaring drift. Defaults to 2.258.
+        :param max_size_concept: Maximum number of instances allowed in a stable concept
+            before forcing an RDDM reset when no warning is active. Defaults to 40000.
+        :param min_size_concept: Size of the internal prediction buffer and the minimum
+            stable concept length retained for recovery after warnings. Defaults to
+            7000.
+        :param warning_limit: Number of consecutive warning instances allowed before
+            warning is promoted to drift. Defaults to 1400.
+        """
 
-        self.min_n_instances = min_n_instances
-        self.warning_level = warning_level
-        self.drift_level = drift_level
-        self.max_size_concept = max_size_concept
-        self.min_size_concept = min_size_concept
-        self.warning_limit = warning_limit
-        self.get_params()
+        cli = [
+            f"-n {min_n_instances}",
+            f"-w {warning_level}",
+            f"-o {drift_level}",
+            f"-x {max_size_concept}",
+            f"-y {min_size_concept}",
+            f"-z {warning_limit}",
+        ]
+        super().__init__(cli=" ".join(cli))

--- a/src/capymoa/drift/detectors/seed.py
+++ b/src/capymoa/drift/detectors/seed.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import (
@@ -38,6 +36,8 @@ class SEED(MOADriftDetector):
 
     """
 
+    _moa_detector_type = _SEEDChangeDetector
+
     def __init__(
         self,
         delta: float = 0.05,
@@ -45,22 +45,26 @@ class SEED(MOADriftDetector):
         epsilon_prime: float = 0.01,
         alpha: float = 0.8,
         compress_term: int = 75,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = (
-                f"-d {delta} "
-                f"-b {block_size} "
-                f"-e {epsilon_prime} "
-                f"-a {alpha} "
-                f"-c {compress_term}"
-            )
+        """Create a SEED drift detector.
 
-        super().__init__(moa_detector=_SEEDChangeDetector(), CLI=CLI)
-
-        self.delta = delta
-        self.block_size = block_size
-        self.epsilon_prime = epsilon_prime
-        self.alpha = alpha
-        self.compress_term = compress_term
-        self.get_params()
+        :param delta: Confidence parameter used in the ADWIN-style cut bound inside
+            SEED. Smaller values make drift declarations more conservative. Defaults to
+            0.05.
+        :param block_size: Number of instances per block before drift checks are
+            attempted. Defaults to 32.
+        :param epsilon_prime: Base homogeneity tolerance used by SEED block compression.
+            Defaults to 0.01.
+        :param alpha: Growth parameter used with ``epsilon_prime`` during compression;
+            larger values increase compression tolerance. Defaults to 0.8.
+        :param compress_term: Compression interval controlling how often fixed-term
+            block compression is attempted. Defaults to 75.
+        """
+        cli = [
+            f"-d {delta}",
+            f"-b {block_size}",
+            f"-e {epsilon_prime}",
+            f"-a {alpha}",
+            f"-c {compress_term}",
+        ]
+        super().__init__(cli=" ".join(cli))

--- a/src/capymoa/drift/detectors/stepd.py
+++ b/src/capymoa/drift/detectors/stepd.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from capymoa.drift.base_detector import MOADriftDetector
 
 from moa.classifiers.core.driftdetection import STEPD as _STEPD
@@ -35,19 +33,25 @@ class STEPD(MOADriftDetector):
     Heidelberg: Springer Berlin Heidelberg, 2007.
     """
 
+    _moa_detector_type = _STEPD
+
     def __init__(
         self,
         window_size: int = 30,
         alpha_drift: float = 0.003,
         alpha_warning: float = 0.05,
-        CLI: Optional[str] = None,
     ):
-        if CLI is None:
-            CLI = f"-r {window_size} -o {alpha_drift} -w {alpha_warning}"
+        """Create a STEPD drift detector.
 
-        super().__init__(moa_detector=_STEPD(), CLI=CLI)
-
-        self.window_size = window_size
-        self.alpha_drift = alpha_drift
-        self.alpha_warning = alpha_warning
-        self.get_params()
+        :param window_size: Size of the recent window used by STEPD to compare recent
+            and older prediction proportions. Larger values smooth short-term noise but
+            usually react more slowly. Defaults to 30.
+        :param alpha_drift: Significance level for declaring drift. Smaller values make
+            drift alarms more conservative; larger values make them easier to trigger.
+            Defaults to 0.003.
+        :param alpha_warning: Significance level for entering warning state. This is
+            typically less strict than ``alpha_drift`` so warnings can appear before
+            full drift. Defaults to 0.05.
+        """
+        cli = f"-r {window_size} -o {alpha_drift} -w {alpha_warning}"
+        super().__init__(cli=cli)

--- a/src/capymoa/prediction_interval/_adaptive_prediction_interval.py
+++ b/src/capymoa/prediction_interval/_adaptive_prediction_interval.py
@@ -2,8 +2,8 @@ import inspect
 
 from capymoa.base import (
     MOAPredictionIntervalLearner,
-    _extract_moa_learner_CLI,
 )
+from capymoa._cli import cli_str_regressor
 
 from capymoa.regressor import AdaptiveRandomForestRegressor
 
@@ -41,13 +41,13 @@ class AdaPI(MOAPredictionIntervalLearner):
             else:
                 if key == "base_learner":
                     if base_learner is None:
-                        set_value = _extract_moa_learner_CLI(
+                        set_value = cli_str_regressor(
                             AdaptiveRandomForestRegressor(schema)
                         )
                     elif type(base_learner) is str:
                         set_value = base_learner
                     else:
-                        set_value = _extract_moa_learner_CLI(base_learner)
+                        set_value = cli_str_regressor(base_learner)
 
                 str_extension = f"{mappings[key]} {set_value} "
             config_str += str_extension

--- a/src/capymoa/prediction_interval/_mean_and_standard_deviation_estimation.py
+++ b/src/capymoa/prediction_interval/_mean_and_standard_deviation_estimation.py
@@ -2,8 +2,8 @@ import inspect
 
 from capymoa.base import (
     MOAPredictionIntervalLearner,
-    _extract_moa_learner_CLI,
 )
+from capymoa._cli import cli_str_regressor
 
 from capymoa.regressor import AdaptiveRandomForestRegressor
 
@@ -36,13 +36,13 @@ class MVE(MOAPredictionIntervalLearner):
             else:
                 if key == "base_learner":
                     if base_learner is None:
-                        set_value = _extract_moa_learner_CLI(
+                        set_value = cli_str_regressor(
                             AdaptiveRandomForestRegressor(schema)
                         )
                     elif type(base_learner) is str:
                         set_value = base_learner
                     else:
-                        set_value = _extract_moa_learner_CLI(base_learner)
+                        set_value = cli_str_regressor(base_learner)
 
                 str_extension = f"{mappings[key]} {set_value} "
             config_str += str_extension

--- a/src/capymoa/regressor/_adaptive_random_forest.py
+++ b/src/capymoa/regressor/_adaptive_random_forest.py
@@ -1,12 +1,16 @@
 # Library imports
 
-from capymoa.base import MOARegressor, _extract_moa_learner_CLI
+from capymoa.base import MOARegressor
+from capymoa._cli import cli_str
 from ._arffimtdd import ARFFIMTDD
-
-
-from moa.classifiers.meta import (
-    AdaptiveRandomForestRegressor as MOA_AdaptiveRandomForestRegressor,
+from capymoa._cli import (
+    cli_str_drift_detector,
 )
+from capymoa.drift.base_detector import MOADriftDetector
+from moa.classifiers.meta import (
+    AdaptiveRandomForestRegressor as _AdaptiveRandomForestRegressor,
+)
+from moa.classifiers.trees import ARFFIMTDD as J_ARFFIMTDD
 
 
 class AdaptiveRandomForestRegressor(MOARegressor):
@@ -30,10 +34,10 @@ class AdaptiveRandomForestRegressor(MOARegressor):
 
     Example usage:
 
-    >>> from capymoa.datasets import Fried
+    >>> from capymoa.datasets import FriedTiny
     >>> from capymoa.regressor import AdaptiveRandomForestRegressor
     >>> from capymoa.evaluation import prequential_evaluation
-    >>> stream = Fried()
+    >>> stream = FriedTiny()
     >>> schema = stream.get_schema()
     >>> learner = AdaptiveRandomForestRegressor(schema)
     >>> results = prequential_evaluation(stream, learner, max_instances=1000)
@@ -44,7 +48,6 @@ class AdaptiveRandomForestRegressor(MOARegressor):
     def __init__(
         self,
         schema=None,
-        CLI=None,
         random_seed=1,
         tree_learner=None,
         ensemble_size=100,
@@ -75,70 +78,57 @@ class AdaptiveRandomForestRegressor(MOARegressor):
         :param disable_drift_detection: Whether to disable drift detection.
         :param disable_background_learner: Whether to disable background learning.
         """
-
-        self.moa_learner = MOA_AdaptiveRandomForestRegressor()
-
-        # Initialize instance attributes with default values, CLI was not set.
-        if CLI is None:
-            if tree_learner is None:
-                self.tree_learner = ARFFIMTDD(
-                    schema, grace_period=50, split_confidence=0.01
-                )
-            elif isinstance(tree_learner, ARFFIMTDD):
-                self.tree_learner = tree_learner
-            elif type(tree_learner) is str:
-                self.tree_learner = tree_learner
-            else:
-                self.tree_learner = _extract_moa_learner_CLI(tree_learner)
-
-            self.ensemble_size = ensemble_size
-
-            self.max_features = max_features
-            if isinstance(self.max_features, float) and 0.0 <= self.max_features <= 1.0:
-                self.m_features_mode = "(Percentage (M * (m / 100)))"
-                self.m_features_per_tree_size = int(self.max_features * 100)
-            elif isinstance(self.max_features, int):
-                self.m_features_mode = "(Specified m (integer value))"
-                self.m_features_per_tree_size = max_features
-            elif self.max_features in ["sqrt"]:
-                self.m_features_mode = "(sqrt(M)+1)"
-                self.m_features_per_tree_size = -1  # or leave it unchanged
-            elif self.max_features is None:
-                self.m_features_mode = "(Percentage (M * (m / 100)))"
-                self.m_features_per_tree_size = 60
-            else:
-                # Raise an exception with information about valid options for max_features
-                raise ValueError(
-                    "Invalid value for max_features. Valid options: float between 0.0 and 1.0 "
-                    "representing percentage, integer specifying exact number, or 'sqrt' for "
-                    "square root of total features."
-                )
-
-            self.lambda_param = lambda_param
-            self.drift_detection_method = (
-                "(ADWINChangeDetector -a 1.0E-3)"
-                if drift_detection_method is None
-                else drift_detection_method
+        if isinstance(max_features, float) and 0.0 <= max_features <= 1.0:
+            m_features_mode = "Percentage (M * (m / 100))"
+            m_features_per_tree_size = int(max_features * 100)
+        elif isinstance(max_features, int):
+            m_features_mode = "Specified m (integer value)"
+            m_features_per_tree_size = max_features
+        elif max_features in ["sqrt"]:
+            m_features_mode = "sqrt(M)+1"
+            m_features_per_tree_size = -1  # or leave it unchanged
+        elif max_features is None:
+            m_features_mode = "Percentage (M * (m / 100))"
+            m_features_per_tree_size = 60
+        else:
+            # Raise an exception with information about valid options for max_features
+            raise ValueError(
+                "Invalid value for max_features. Valid options: float between 0.0 and 1.0 "
+                "representing percentage, integer specifying exact number, or 'sqrt' for "
+                "square root of total features."
             )
-            self.warning_detection_method = (
-                "(ADWINChangeDetector -a 1.0E-2)"
-                if warning_detection_method is None
-                else warning_detection_method
-            )
-            self.disable_drift_detection = disable_drift_detection
-            self.disable_background_learner = disable_background_learner
 
-            self.moa_learner.getOptions().setViaCLIString(
-                f"-l ({self.tree_learner.__class__.__name__} {self.tree_learner.CLI}) -s {self.ensemble_size} -o {self.m_features_mode} -m \
-                {self.m_features_per_tree_size} -a {self.lambda_param} -x {self.drift_detection_method} -p \
-                {self.warning_detection_method} {'-u' if self.disable_drift_detection else ''}  {'-q' if self.disable_background_learner else ''}"
-            )
-            self.moa_learner.prepareForUse()
-            self.moa_learner.resetLearning()
+        if tree_learner is None:
+            tree_learner = ARFFIMTDD(schema, grace_period=50, split_confidence=0.01)
+        if isinstance(tree_learner, ARFFIMTDD):
+            tree_learner = cli_str(tree_learner.moa_learner, J_ARFFIMTDD)
+        if isinstance(drift_detection_method, MOADriftDetector):
+            drift_detection_method = cli_str_drift_detector(drift_detection_method)
+        if isinstance(warning_detection_method, MOADriftDetector):
+            warning_detection_method = cli_str_drift_detector(warning_detection_method)
 
+        cli = [
+            f"-l {tree_learner}",
+            f"-s {ensemble_size}",
+            f"-o '{m_features_mode}'",
+            f"-m {m_features_per_tree_size}",
+            f"-a {lambda_param}",
+        ]
+
+        # Optional options
+        if drift_detection_method is not None:
+            cli.append(f"-x {drift_detection_method}")
+        if warning_detection_method is not None:
+            cli.append(f"-p {warning_detection_method}")
+        if disable_drift_detection:
+            cli.append("-u")
+        if disable_background_learner:
+            cli.append("-q")
+
+        moa_learner = _AdaptiveRandomForestRegressor()
         super().__init__(
+            moa_learner=moa_learner,
             schema=schema,
-            CLI=CLI,
+            CLI=" ".join(cli),
             random_seed=random_seed,
-            moa_learner=self.moa_learner,
         )

--- a/src/capymoa/regressor/_soknl.py
+++ b/src/capymoa/regressor/_soknl.py
@@ -3,7 +3,8 @@
 from ._soknl_base_tree import SOKNLBT
 from moa.classifiers.meta import SelfOptimisingKNearestLeaves as _MOA_SOKNL
 
-from capymoa.base import MOARegressor, _extract_moa_learner_CLI
+from capymoa.base import MOARegressor
+from capymoa._cli import cli_str_regressor
 
 
 class SOKNL(MOARegressor):
@@ -69,7 +70,7 @@ class SOKNL(MOARegressor):
             elif type(tree_learner) is str:
                 self.tree_learner = tree_learner
             else:
-                self.tree_learner = _extract_moa_learner_CLI(tree_learner)
+                self.tree_learner = cli_str_regressor(tree_learner)
 
             self.ensemble_size = ensemble_size
 

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from itertools import cycle
 
 from capymoa.stream import MOAStream
-from capymoa._utils import _get_moa_creation_CLI
+from capymoa._cli import cli_str_stream
 from moa.streams import ConceptDriftStream as MOA_ConceptDriftStream
 
 
@@ -60,7 +60,7 @@ class DriftStream(MOAStream):
                             )
 
                         CLI += (
-                            f" -d {_get_moa_creation_CLI(stream2.moa_stream)} -w {drift.width} -p "
+                            f" -d {cli_str_stream(stream2.moa_stream)} -w {drift.width} -p "
                             f"{drift.position} -r {drift.random_seed} -a {drift.alpha}"
                         )
                         CLI = CLI.replace(
@@ -76,7 +76,7 @@ class DriftStream(MOAStream):
                     # print(component)
                     drift = component
                     self.drifts.append(drift)
-                    CLI = f" -s {_get_moa_creation_CLI(stream1.moa_stream)} "
+                    CLI = f" -s {cli_str_stream(stream1.moa_stream)} "
 
             moa_stream = MOA_ConceptDriftStream()
         else:

--- a/tests/test_anomaly_detectors.py
+++ b/tests/test_anomaly_detectors.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Callable, Optional
+from capymoa._cli import cli_str_classifier
 
 import pytest
 
@@ -14,7 +15,7 @@ from capymoa.anomaly import (
     StreamingIsolationForest,
     StreamRHF,
 )
-from capymoa.base import AnomalyDetector, MOAClassifier, _extract_moa_learner_CLI
+from capymoa.base import AnomalyDetector, MOAClassifier
 from capymoa.datasets import ElectricityTiny
 from capymoa.evaluation import AnomalyDetectionEvaluator
 from capymoa.stream._stream import Schema
@@ -147,5 +148,5 @@ def test_anomaly_detectors(
 
     # Optionally check the CLI string if it was provided
     if isinstance(learner, MOAClassifier) and cli_string is not None:
-        cli_str = _extract_moa_learner_CLI(learner).strip("()")
+        cli_str = cli_str_classifier(learner).strip("()")
         assert cli_str == cli_string, "CLI does not match expected value"

--- a/tests/test_bandit_classifier.py
+++ b/tests/test_bandit_classifier.py
@@ -3,7 +3,7 @@ import tempfile
 
 from capymoa.automl import BanditClassifier, EpsilonGreedy
 from capymoa.stream.generator import SEA
-from capymoa.base import _extract_moa_learner_CLI
+from capymoa._cli import cli_str_classifier
 
 
 def test_bandit_classifier_parameter_initialization():
@@ -40,7 +40,7 @@ def test_bandit_classifier_parameter_initialization():
     model = bc.active_models[0]
 
     # Check that the constructor parameter was applied (CLI should include "-g 50")
-    cli_str = _extract_moa_learner_CLI(model)
+    cli_str = cli_str_classifier(model)
     assert "-g 50" in cli_str, f"Expected grace_period=50, got CLI: {cli_str}"
 
     # Basic functional check

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -10,8 +10,9 @@ import torch
 from java.lang import Exception as JException
 from pytest_subtests import SubTests
 
+from capymoa._cli import cli_str_classifier
 from capymoa.ann import Perceptron
-from capymoa.base import Classifier, MOAClassifier, _extract_moa_learner_CLI
+from capymoa.base import Classifier, MOAClassifier
 from capymoa.classifier import (
     CSMOTE,
     EFDT,
@@ -353,5 +354,5 @@ def test_classifiers(test_case: ClassifierTestCase, subtests: SubTests):
 
     # Optionally check the CLI string if it was provided
     if isinstance(learner, MOAClassifier) and test_case.cli_string is not None:
-        cli_str = _extract_moa_learner_CLI(learner).strip("()")
+        cli_str = cli_str_classifier(learner).strip("()")
         assert cli_str == test_case.cli_string, "CLI does not match expected value"

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,31 @@
+from capymoa.drift import detectors
+from capymoa.drift.base_detector import BaseDriftDetector, MOADriftDetector
+import inspect
+import pytest
+
+
+def test_from_cli():
+    cli = "-a 0.01"
+    detector = detectors.ADWIN.from_cli(cli)
+    assert detector.cli == "(driftdetection.ADWINChangeDetector -a 0.01)"
+
+
+@pytest.mark.parametrize("detector_name", detectors.__all__)
+def test_constructors(detector_name: str):
+    detector_cls = getattr(detectors, detector_name)
+
+    # Skip any that require positional arguments
+    parameters = inspect.signature(detector_cls).parameters
+    if any(p.default is inspect.Parameter.empty for p in parameters.values()):
+        pytest.skip(f"{detector_name} has required positional arguments.")
+
+    detector = detector_cls()
+    assert isinstance(detector, BaseDriftDetector)
+
+    if isinstance(detector, MOADriftDetector):
+        assert detector._moa_detector_type is not None, (
+            "MOADriftDetector MUST set _moa_detector_type appropriately."
+        )
+        assert isinstance(detector.moa_detector, detector._moa_detector_type), (
+            "MOA detector instance must be of type specified by _moa_detector_type."
+        )

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,4 +1,5 @@
 from capymoa.drift import detectors
+from capymoa._cli import cli_str_drift_detector
 from capymoa.drift.base_detector import BaseDriftDetector, MOADriftDetector
 import inspect
 import pytest
@@ -7,7 +8,8 @@ import pytest
 def test_from_cli():
     cli = "-a 0.01"
     detector = detectors.ADWIN.from_cli(cli)
-    assert detector.cli == "(driftdetection.ADWINChangeDetector -a 0.01)"
+    assert isinstance(detector, detectors.ADWIN)
+    assert cli_str_drift_detector(detector) == "(ADWINChangeDetector -a 0.01)"
 
 
 @pytest.mark.parametrize("detector_name", detectors.__all__)
@@ -22,7 +24,9 @@ def test_constructors(detector_name: str):
     detector = detector_cls()
     assert isinstance(detector, BaseDriftDetector)
 
+    # Test only MOA drift detectors
     if isinstance(detector, MOADriftDetector):
+        assert isinstance(detector_cls.from_cli(""), detector_cls)
         assert detector._moa_detector_type is not None, (
             "MOADriftDetector MUST set _moa_detector_type appropriately."
         )

--- a/tests/test_successive_halving.py
+++ b/tests/test_successive_halving.py
@@ -3,7 +3,7 @@ import tempfile
 
 from capymoa.automl import SuccessiveHalvingClassifier
 from capymoa.stream.generator import SEA
-from capymoa.base import _extract_moa_learner_CLI
+from capymoa._cli import cli_str_classifier
 
 
 def test_successive_halving_parameter_initialization():
@@ -40,7 +40,7 @@ def test_successive_halving_parameter_initialization():
     model = sh.active_models[0]
 
     # Check that constructor parameters were applied ("-g 30" for grace_period)
-    cli_str = _extract_moa_learner_CLI(model)
+    cli_str = cli_str_classifier(model)
     assert "-g 30" in cli_str, f"Expected grace_period=30, got CLI: {cli_str}"
 
     # Basic functional check

--- a/tools/template/MOAClassifier.py.jinja
+++ b/tools/template/MOAClassifier.py.jinja
@@ -1,4 +1,4 @@
-from capymoa.base._base import _extract_moa_learner_CLI
+from capymoa._cli import classifier_cli_str
 from capymoa.stream import Schema
 from capymoa.base import MOAClassifier
 from typing import Literal
@@ -39,7 +39,7 @@ class {{j_class}}(MOAClassifier):
 
         {% for option in options if option.option_type == "MoaClassOption" %}
         if isinstance({{option.name}}, MOAClassifier):
-            {{option.name}} = _extract_moa_learner_CLI({{option.name}})
+            {{option.name}} = classifier_cli_str({{option.name}})
         {%- endfor %}
 
         cli = []


### PR DESCRIPTION
* Add doc strings to drift detector creation. This was done using an LLM. I did ground the documentation using the MOA source code so I reckon it should be okay.
* Rather than using `Detector(CLI=...)` this is now written as `Detector.from_cli(...)`. The main constructor is just for arguments `Detector(delta=0.1)`. This gives users one way to do each thing rather than one way to do two things. I can imagine someone overriding their parameters with `CLI=` or being confused when it used MOA defaults instead of CapyMOA defaults. I also simplified some constructor logic. I'm considering using a similar pattern for classifiers as well, if we like it.