### PR TITLE
build: pin ruff so the lint gate and dev install agree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ dev=[
     "pytest-subtests~=0.15",
     "pytest-xdist~=3.8",
     "pytest~=9.0",
-    "ruff~=0.14",
+    # Pinned to a single minor: `astral-sh/ruff-action` (the Code Style gate) reads this spec
+    # as >=0.14,<0.15, while pip/uv apply PEP 440 and admit 0.16.x. An explicit range keeps
+    # the lint gate and dev installs on the same ruff. Bumping is a deliberate change.
+    "ruff>=0.14,<0.15",
     "stubgenj~=0.2",
     "wget~=3.2",
 ]


### PR DESCRIPTION
## What and why

`pyproject.toml` declared `ruff~=0.14`, which resolves to **two different versions of ruff inside the same CI run**:

| CI job | How ruff is installed | Version |
|---|---|---|
| **Code Style** (`.github/workflows/pr.yml`) | `astral-sh/ruff-action@v3`, reading the spec from `pyproject.toml` | **0.14.14** |
| **Tests**, **Documentation** | `pip install ".[dev]"` | **0.16.1** |

`ruff-action` reads `~=0.14` as `>=0.14,<0.15`; pip/uv apply PEP 440, where `~=0.14` means `>=0.14, ==0.*` and so admits 0.16.x. Both versions appear in the log of a single green run ([30811290306](https://github.com/adaptive-machine-learning/CapyMOA/actions/runs/30811290306)).

Only the Code Style job can fail a PR, so CI stayed green — but 0.16.1 is the version every contributor ends up with locally.

## Impact this fixes

ruff 0.16.0 widened its default rule set considerably. On a clean checkout of `main`, with the repo's own config:

| ruff | `ruff check` | `ruff format --check` |
|---|---|---|
| 0.14.14 | All checks passed | 206 files already formatted |
| 0.15.0 | All checks passed | clean |
| **0.16.1** | **888 errors** | **1 file would be reformatted** |

`invoke fmt` runs `ruff format` then `ruff check --fix`, so a contributor doing the documented setup:

```bash
pip install --editable ".[dev,doc]"   # gets ruff 0.16.1
invoke fmt
```

rewrote **186 files, 3799 insertions(+) / 3737 deletions(-)** — none of which the gate asked for. And it did not converge: `982 errors (799 fixed, 183 remaining)`, so the tree still failed `ruff check` afterwards, with no clean state reachable.

## The change

One line in `pyproject.toml`, plus a comment explaining why it is not a plain `~=`:

```toml
"ruff>=0.14,<0.15",
```

An explicit range is unambiguous to both resolvers — `ruff-action` documents PEP 440 range support (`>=0.11.10,<0.12.0`).

## Validation

Verified both resolvers now land on the same build:

| spec | pip/uv resolves to | `ruff-action` installs |
|---|---|---|
| `~=0.14` (before) | 0.16.1 | 0.14.14 |
| `>=0.14,<0.15` (after) | **0.14.14** | **0.14.14** |

- `uv pip compile --extra dev pyproject.toml` → `ruff==0.14.14`
- `ruff format --check` → 206 files already formatted
- `ruff check` → All checks passed

0.14.14 is currently the newest 0.14.x, so this pins to the latest patch of that minor rather than to an older build. No source files are touched.

## Deliberately out of scope

This fixes the *inconsistency*, not the staleness — it does not adopt ruff 0.16. That upgrade is real work (186 files, ~3.8k lines, and 183 errors needing manual attention) and should be its own deliberate `style:` PR moving the spec to `>=0.16,<0.17`, rather than arriving implicitly through a contributor's fresh install. Pinning first and modernising second keeps the two reviewable.

Also worth considering separately: echoing the resolved ruff version in the Code Style job output, so a future divergence shows up in the log instead of having to be discovered by hand.

Closes #368.
