### PR TITLE
feat: make PyTorch an optional extra

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,79 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         files: coverage.xml
 
+  no-torch:
+    # PyTorch is an optional extra. This job installs CapyMOA *without* extras
+    # and checks the core still imports and runs, so `pip install capymoa` never
+    # silently goes back to pulling the ~2.9 GB CUDA stack. Without this job the
+    # regression returns the first time someone adds a top-level `import torch`
+    # to a core module.
+    name: "Install without PyTorch"
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'pip'
+
+    - name: Install CapyMOA with no extras
+      run: python -m pip install .
+
+    - name: Assert PyTorch is absent
+      run: |
+        if python -c "import torch" 2>/dev/null; then
+          echo '::error::torch was installed by a bare "pip install capymoa".'
+          python -m pip show torch
+          exit 1
+        fi
+        echo "torch is not installed, as expected"
+
+    - name: Core imports and runs without PyTorch
+      # Run from a different directory so `capymoa` resolves to the installed
+      # package rather than ./src.
+      working-directory: /tmp
+      run: |
+        python - <<'PY'
+        import sys
+
+        import capymoa
+        assert "torch" not in sys.modules, "importing capymoa pulled in torch"
+
+        from capymoa.classifier import AdaptiveRandomForestClassifier
+        from capymoa.datasets import ElectricityTiny
+        from capymoa.evaluation import prequential_evaluation
+
+        stream = ElectricityTiny()
+        learner = AdaptiveRandomForestClassifier(schema=stream.get_schema())
+        results = prequential_evaluation(stream, learner, max_instances=1000)
+        accuracy = results["cumulative"].accuracy()
+        assert accuracy > 50, accuracy
+        assert "torch" not in sys.modules, "the evaluation loop pulled in torch"
+        print(f"OK -- accuracy {accuracy:.1f} with no PyTorch installed")
+        PY
+
+    - name: Torch-only features raise a helpful error
+      working-directory: /tmp
+      run: |
+        python - <<'PY'
+        from capymoa.exception import OptionalDependencyError
+
+        for importer in (
+            lambda: __import__("capymoa.ocl"),
+            lambda: __import__("capymoa.ann"),
+        ):
+            try:
+                importer()
+            except OptionalDependencyError as err:
+                assert "pip install capymoa[torch]" in str(err), err
+            else:
+                raise AssertionError("expected OptionalDependencyError")
+        print("OK -- optional-dependency errors are actionable")
+        PY
+
   lint:
     name: "Code Style"
     timeout-minutes: 10

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -139,6 +139,29 @@ jobs:
         print(f"OK -- accuracy {accuracy:.1f} with no PyTorch installed")
         PY
 
+    - name: Wildcard imports work without PyTorch
+      working-directory: /tmp
+      run: |
+        python - <<'PY'
+        # __all__ drives `import *`; torch-only names must not be listed when
+        # torch is absent, or a wildcard import fails for core-only users.
+        import capymoa.base as base
+
+        for module in (
+            "capymoa.base",
+            "capymoa.classifier",
+            "capymoa.stream",
+            "capymoa.anomaly",
+            "capymoa.ssl",
+            "capymoa.drift.detectors",
+        ):
+            exec(f"from {module} import *")
+
+        assert "BatchClassifier" not in base.__all__
+        assert "Classifier" in base.__all__
+        print("OK -- wildcard imports resolve without PyTorch")
+        PY
+
     - name: Torch-only features raise a helpful error
       working-directory: /tmp
       run: |

--- a/README.md
+++ b/README.md
@@ -16,14 +16,21 @@ offline. CapyMOA is a toolbox of methods and evaluators for: classification, reg
 clustering, anomaly detection, semi-supervised learning, online continual learning, and
 drift detection for data streams.
 
-For the default PyTorch CUDA GPU installation, run:
+To install:
 
 ```
 pip install capymoa
 ```
 
+The deep-learning parts of CapyMOA (`capymoa.ocl`, `capymoa.ann`, the `Batch*`
+learners) need PyTorch, which is an optional extra:
+
+```
+pip install capymoa[torch]
+```
+
 Refer to the [Setup](https://capymoa.org/setup) guide for other options,
-including CPU-only and dev dependencies.
+including CPU-only PyTorch and dev dependencies.
 
 ```python
 from capymoa.datasets import Electricity

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,9 @@ nitpick_ignore_regex = [
     ("py:class", r"torchvision\..*"),
     ("py:class", r"Tensor"),
     ("py:class", r"nn\.Module"),
+    # `autodoc_typehints_format = "short"` renders
+    # torch.optim.optimizer.Optimizer as a bare name, like Tensor above.
+    ("py:class", r"Optimizer"),
 ]
 
 # These warnings are usually false positives.

--- a/docs/setup/developer.rst
+++ b/docs/setup/developer.rst
@@ -68,6 +68,11 @@ dependencies.
       cd CapyMOA
       pip install --editable ".[dev,doc]"
 
+   The ``dev`` extra includes the ``torch`` extra, so a development install has
+   PyTorch and can run the whole test suite. On Linux, install the CPU build of
+   PyTorch first if you do not want the CUDA packages -- see the PyTorch note in
+   :doc:`/setup/index`.
+
 
 #. **Congratulations!**
 

--- a/docs/setup/index.rst
+++ b/docs/setup/index.rst
@@ -105,16 +105,35 @@ or have Java installed outside of the system path.
 PyTorch
 ~~~~~~~
 
-The CapyMOA algorithms using deep learning require PyTorch. If you want to use
-these algorithms, follow the instructions
-`here <https://pytorch.org/get-started/locally/>`__ to get the correct version for
-your hardware. Ensure that you install PyTorch in the same virtual environment
-where you want to install CapyMOA.
+PyTorch is **optional**. ``pip install capymoa`` does not install it, so the
+core of CapyMOA -- streams, classifiers, regressors, drift detectors and
+evaluation -- installs without pulling a deep-learning stack.
 
-For CPU only, you can install PyTorch with:
+The parts of CapyMOA that use deep learning do require it:
+:mod:`capymoa.ocl`, :mod:`capymoa.ann`, :class:`capymoa.stream.TorchStream`,
+the ``Batch*`` learners, :class:`capymoa.anomaly.Autoencoder`,
+:class:`capymoa.classifier.Finetune`, :class:`capymoa.ssl.OSNN` and the ABCD
+drift detector. Using one of those without PyTorch raises an
+``OptionalDependencyError`` telling you what to install.
+
+Install CapyMOA with PyTorch using the ``torch`` extra:
 
 .. code:: bash
 
-   pip3 install torch torchvision torchaudio \
-      --index-url https://download.pytorch.org/whl/cpu
+   pip install capymoa[torch]
+
+.. note::
+
+   On Linux the default PyPI PyTorch wheel is CUDA-enabled and pulls the NVIDIA
+   stack (several GB). If you do not need a GPU, install the CPU build *first*
+   and then CapyMOA -- pip will keep the version you already have:
+
+   .. code:: bash
+
+      pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+      pip install capymoa[torch]
+
+To match a specific GPU or CUDA version instead, follow the instructions
+`here <https://pytorch.org/get-started/locally/>`__, and make sure PyTorch goes
+into the same virtual environment as CapyMOA.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,25 @@ dependencies = [
     "scikit-learn~=1.7",
     "seaborn~=0.13",
     "tqdm~=4.67",
+    # `typing_extensions.override` is used across the core modules. It used to
+    # arrive transitively via torch; now that torch is an optional extra it has
+    # to be declared explicitly.
+    "typing-extensions~=4.10",
+]
+
+[project.optional-dependencies]
+# PyTorch is optional: it is only needed by the deep-learning parts of CapyMOA
+# (capymoa.ocl, capymoa.ann, capymoa.stream.torch, the Batch* learners,
+# Autoencoder and ABCD's feature extraction). Keeping it out of the default
+# install avoids pulling the CUDA stack (~2.9 GB on Linux) on `pip install capymoa`.
+torch=[
     "torch~=2.9",
     "torchvision~=0.24",
 ]
 
-[project.optional-dependencies]
 # Development dependencies
 dev=[
+    "capymoa[torch]",
     "commitizen~=3.24",
     "invoke~=3.0",
     "jupyter~=1.1",

--- a/src/capymoa/_optional.py
+++ b/src/capymoa/_optional.py
@@ -1,0 +1,67 @@
+"""Helpers for exposing optional-dependency-backed names lazily.
+
+CapyMOA keeps PyTorch out of the default installation (see the ``torch`` extra in
+``pyproject.toml``). Some public names -- ``capymoa.classifier.Finetune``,
+``capymoa.anomaly.Autoencoder``, the ``Batch*`` base classes, everything in
+``capymoa.ocl`` and ``capymoa.ann`` -- genuinely need PyTorch and cannot be
+imported without it.
+
+Re-exporting those eagerly from a package ``__init__`` would drag PyTorch into
+``import capymoa``, which defeats the whole point. Instead each package declares
+them here and they are imported on first attribute access, using :pep:`562`
+module-level ``__getattr__``.
+
+The user-visible behaviour is unchanged when PyTorch *is* installed:
+``from capymoa.classifier import Finetune`` works exactly as before. Without
+PyTorch the same import raises
+:class:`~capymoa.exception.OptionalDependencyError` naming the feature and the
+install command, instead of a bare ``ModuleNotFoundError``.
+"""
+
+from importlib import import_module
+from typing import Any, Callable, Dict, List, Mapping, Tuple
+
+__all__ = ["lazy_torch_attrs"]
+
+
+def lazy_torch_attrs(
+    package: str,
+    mapping: Mapping[str, str],
+    feature: str,
+    static: List[str] = (),
+) -> Tuple[Callable[[str], Any], Callable[[], List[str]]]:
+    """Build ``__getattr__``/``__dir__`` that import torch-backed names lazily.
+
+    Use it at the bottom of a package ``__init__.py``::
+
+        _LAZY = {"Finetune": "._finetune"}
+        __getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "Finetune", __all__)
+
+    :param package: ``__name__`` of the calling package.
+    :param mapping: Public name -> module to import it from, relative to
+        ``package`` (e.g. ``{"Finetune": "._finetune"}``).
+    :param feature: What the user was reaching for, used in the error message.
+    :param static: Names already imported eagerly, so ``dir()`` stays complete.
+    :return: ``(__getattr__, __dir__)`` to assign in the calling module.
+    """
+    lazy: Dict[str, str] = dict(mapping)
+    known = sorted(set(static) | set(lazy))
+
+    def __getattr__(name: str) -> Any:
+        module_name = lazy.get(name)
+        if module_name is None:
+            raise AttributeError(f"module {package!r} has no attribute {name!r}")
+        # Raise a helpful error before the ModuleNotFoundError from the import.
+        from capymoa.exception import _requires_torch
+
+        _requires_torch(feature)
+        module = import_module(module_name, package)
+        value = getattr(module, name)
+        # Cache on the package so repeated access skips this machinery.
+        setattr(import_module(package), name, value)
+        return value
+
+    def __dir__() -> List[str]:
+        return known
+
+    return __getattr__, __dir__

--- a/src/capymoa/_optional.py
+++ b/src/capymoa/_optional.py
@@ -18,17 +18,29 @@ PyTorch the same import raises
 install command, instead of a bare ``ModuleNotFoundError``.
 """
 
+from functools import lru_cache
 from importlib import import_module
-from typing import Any, Callable, Dict, List, Mapping, Tuple
+from typing import Any, Callable, Dict, List, Mapping, MutableSequence, Tuple
 
-__all__ = ["lazy_torch_attrs"]
+__all__ = ["lazy_torch_attrs", "torch_available"]
+
+
+@lru_cache(maxsize=1)
+def torch_available() -> bool:
+    """Whether PyTorch can be imported, resolved once per process."""
+    from importlib.util import find_spec
+
+    try:
+        return find_spec("torch") is not None
+    except (ImportError, ValueError):
+        return False
 
 
 def lazy_torch_attrs(
     package: str,
     mapping: Mapping[str, str],
     feature: str,
-    static: List[str] = (),
+    all_names: MutableSequence[str],
 ) -> Tuple[Callable[[str], Any], Callable[[], List[str]]]:
     """Build ``__getattr__``/``__dir__`` that import torch-backed names lazily.
 
@@ -37,24 +49,40 @@ def lazy_torch_attrs(
         _LAZY = {"Finetune": "._finetune"}
         __getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "Finetune", __all__)
 
+    When PyTorch is **not** installed the lazy names are removed from
+    ``all_names`` in place. ``__all__`` drives ``from package import *``, so
+    leaving them listed would make a wildcard import resolve every torch-backed
+    name and fail with :class:`~capymoa.exception.OptionalDependencyError`, even
+    for a user who only wanted the core names. Dropping them means
+    ``import *`` yields exactly what is usable, while an explicit
+    ``from capymoa.classifier import Finetune`` still raises the actionable
+    error. With PyTorch installed, ``__all__`` is left untouched.
+
     :param package: ``__name__`` of the calling package.
     :param mapping: Public name -> module to import it from, relative to
         ``package`` (e.g. ``{"Finetune": "._finetune"}``).
     :param feature: What the user was reaching for, used in the error message.
-    :param static: Names already imported eagerly, so ``dir()`` stays complete.
+    :param all_names: The package's ``__all__``. Filtered in place when PyTorch
+        is missing, as described above.
     :return: ``(__getattr__, __dir__)`` to assign in the calling module.
     """
     lazy: Dict[str, str] = dict(mapping)
-    known = sorted(set(static) | set(lazy))
+    known = sorted(set(all_names) | set(lazy))
+
+    if not torch_available():
+        for name in lazy:
+            while name in all_names:
+                all_names.remove(name)
 
     def __getattr__(name: str) -> Any:
         module_name = lazy.get(name)
         if module_name is None:
             raise AttributeError(f"module {package!r} has no attribute {name!r}")
         # Raise a helpful error before the ModuleNotFoundError from the import.
-        from capymoa.exception import _requires_torch
+        from capymoa.exception import OptionalDependencyError
 
-        _requires_torch(feature)
+        if not torch_available():
+            raise OptionalDependencyError("PyTorch", feature)
         module = import_module(module_name, package)
         value = getattr(module, name)
         # Cache on the package so repeated access skips this machinery.

--- a/src/capymoa/_optional.py
+++ b/src/capymoa/_optional.py
@@ -62,6 +62,12 @@ def lazy_torch_attrs(
         return value
 
     def __dir__() -> List[str]:
-        return known
+        # Union with the module's real namespace rather than replacing it.
+        # Returning only the curated list hides eagerly-imported names from
+        # tools that enumerate modules via dir() -- Sphinx autosummary then
+        # documents classes under their private module path and every
+        # cross-reference to them breaks.
+        module = import_module(package)
+        return sorted(set(vars(module)) | set(known))
 
     return __getattr__, __dir__

--- a/src/capymoa/ann/__init__.py
+++ b/src/capymoa/ann/__init__.py
@@ -1,15 +1,23 @@
 """Artificial Neural Networks for CapyMOA."""
 
-from ._perceptron import Perceptron
-from ._lenet import LeNet5
-from ._resnet import (
-    resnet20_32x32,
-    resnet32_32x32,
-    resnet44_32x32,
-    resnet56_32x32,
-    resnet110_32x32,
-    resnet1202_32x32,
-)
+# PyTorch is an optional extra; this whole module requires it.
+try:
+    from ._perceptron import Perceptron
+    from ._lenet import LeNet5
+    from ._resnet import (
+        resnet20_32x32,
+        resnet32_32x32,
+        resnet44_32x32,
+        resnet56_32x32,
+        resnet110_32x32,
+        resnet1202_32x32,
+    )
+except ModuleNotFoundError as _err:  # pragma: no cover
+    if (_err.name or "").split(".")[0] in ("torch", "torchvision"):
+        from capymoa.exception import OptionalDependencyError
+
+        raise OptionalDependencyError("PyTorch", "capymoa.ann") from _err
+    raise
 
 __all__ = [
     "Perceptron",

--- a/src/capymoa/anomaly/__init__.py
+++ b/src/capymoa/anomaly/__init__.py
@@ -1,5 +1,5 @@
+from capymoa._optional import lazy_torch_attrs
 from ._adaptive_isolation_forest import AdaptiveIsolationForest
-from ._autoencoder import Autoencoder
 from ._half_space_trees import HalfSpaceTrees
 from ._iforest_asd import IForestASD
 from ._online_isolation_forest import OnlineIsolationForest
@@ -24,3 +24,12 @@ __all__ = [
     "IForestASD",
     "Loda",
 ]
+
+
+#: Names that need PyTorch. Imported on first access so ``import capymoa`` stays
+#: torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "Autoencoder": "._autoencoder",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "Autoencoder", __all__)

--- a/src/capymoa/base/__init__.py
+++ b/src/capymoa/base/__init__.py
@@ -1,3 +1,4 @@
+from capymoa._optional import lazy_torch_attrs
 from capymoa.base._base import (
     AnomalyDetector,
     Clusterer,
@@ -8,17 +9,15 @@ from capymoa.base._base import (
     PredictionIntervalLearner,
 )
 from capymoa.base._classifier import (
-    BatchClassifier,
     Classifier,
     MOAClassifier,
     SKClassifier,
 )
-from capymoa.base._regressor import BatchRegressor, MOARegressor, Regressor, SKRegressor
+from capymoa.base._regressor import MOARegressor, Regressor, SKRegressor
 from capymoa.base._ssl import (
     ClassifierSSL,
     MOAClassifierSSL,
 )
-from ._batch import Batch
 
 __all__ = [
     "Classifier",
@@ -40,3 +39,15 @@ __all__ = [
     "MOAPredictionIntervalLearner",
     "PredictionIntervalLearner",
 ]
+
+#: Names that need PyTorch. Imported on first access so ``import capymoa`` stays
+#: torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "Batch": "._batch",
+    "BatchClassifier": "._batch_classifier",
+    "BatchRegressor": "._batch_regressor",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(
+    __name__, _LAZY, "the Batch* base classes", __all__
+)

--- a/src/capymoa/base/_batch_classifier.py
+++ b/src/capymoa/base/_batch_classifier.py
@@ -1,0 +1,140 @@
+"""Batch classifier base class.
+
+Separated from :mod:`capymoa.base._classifier` so that importing
+:mod:`capymoa.base` does not import PyTorch. :class:`BatchClassifier` cannot
+work without PyTorch, so it is exposed lazily from :mod:`capymoa.base`.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import numpy as np
+import torch
+
+from capymoa.instance import Instance, LabeledInstance
+from capymoa.type_alias import LabelProbabilities
+
+from ._batch import Batch
+from ._classifier import Classifier
+
+
+class BatchClassifier(Classifier, Batch, ABC):
+    """Base class for classifiers that support mini-batches.
+
+    Supported by:
+
+    - :func:`capymoa.ocl.evaluation.ocl_train_eval_loop`
+    - :func:`capymoa.evaluation.prequential_evaluation`
+
+    Evaluators that support batch classifiers will call the :func:`batch_train`
+    and :func:`batch_predict_proba` methods instead of :func:`train` and
+    :func:`predict_proba`:
+
+    >>> from capymoa.base import BatchClassifier
+    >>> from capymoa.datasets import ElectricityTiny
+    >>> from capymoa.evaluation import prequential_evaluation
+    >>>
+    >>> batch_size = 500
+    >>> class MyBatchClassifier(BatchClassifier):
+    ...     def batch_train(self, x, y):
+    ...         print(f"batch_train x: {x.shape} {x.dtype}")
+    ...         print(f"batch_train y: {y.shape} {y.dtype}")
+    ...
+    ...     def batch_predict_proba(self, x):
+    ...         print(f"batch_predict_proba x: {x.shape} {x.dtype}")
+    ...         return torch.zeros((x.shape[0], self.schema.get_num_classes()))
+    ...
+    >>> stream = ElectricityTiny()
+    >>> learner = MyBatchClassifier(stream.get_schema())
+    >>> _ = prequential_evaluation(
+    ...     stream,
+    ...     learner,
+    ...     batch_size=batch_size,
+    ...     max_instances=721
+    ... )
+    batch_predict_proba x: torch.Size([500, 6]) torch.float32
+    batch_train x: torch.Size([500, 6]) torch.float32
+    batch_train y: torch.Size([500]) torch.int64
+    batch_predict_proba x: torch.Size([221, 6]) torch.float32
+    batch_train x: torch.Size([221, 6]) torch.float32
+    batch_train y: torch.Size([221]) torch.int64
+
+    You can manually use ``itertools.batched`` (python 3.12) function and
+    ``np.stack`` to collect batches of instances as a matrix:
+
+    >>> from itertools import islice
+    >>> from capymoa._utils import batched # Not available in python < 3.12
+    >>> stream.restart() # streams are stateful, so restart it
+    >>> for i, batch in enumerate(batched(stream, 100)):
+    ...     x = np.stack([instance.x for instance in batch])
+    ...     y = np.stack([instance.y_index for instance in batch])
+    ...     x = torch.from_numpy(x).to(learner.device, learner.x_dtype)
+    ...     y = torch.from_numpy(y).to(learner.device, learner.y_dtype)
+    ...     learner.batch_train(x, y)
+    ...     break
+    batch_train x: torch.Size([100, 6]) torch.float32
+    batch_train y: torch.Size([100]) torch.int64
+
+    The default implementation of :func:`train` and :func:`predict` calls the
+    batch variants with a batch of size 1. This is useful for parts of CapyMOA
+    that expect a classifier to be able to train and predict on single
+    instances.
+
+    >>> instance = next(stream)
+    >>> learner.train(instance)
+    batch_train x: torch.Size([1, 6]) torch.float32
+    batch_train y: torch.Size([1]) torch.int64
+    >>> learner.predict(instance)
+    batch_predict_proba x: torch.Size([1, 6]) torch.float32
+    0
+    >>> learner.predict_proba(instance)
+    batch_predict_proba x: torch.Size([1, 6]) torch.float32
+    array([0., 0.])
+    """
+
+    x_dtype: torch.dtype = torch.float32
+    y_dtype: torch.dtype = torch.int64
+
+    @abstractmethod
+    def batch_train(self, x: torch.Tensor, y: torch.Tensor) -> None:
+        """Train with a batch of instances.
+
+        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
+            ``(batch_size, num_features)``
+        :param y: Batch of :py:attr:`y_dtype` valued labels ``(batch_size,)``.
+        """
+
+    @abstractmethod
+    def batch_predict_proba(self, x: torch.Tensor) -> torch.Tensor:
+        """Predict the probabilities of the classes for a batch of instances.
+
+        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
+            ``(batch_size, num_features)``
+        :return: Batch of :py:attr:`x_dtype` valued predicted probabilities
+            ``(batch_size, num_classes)``.
+        """
+
+    def batch_predict(self, x: torch.Tensor) -> torch.Tensor:
+        """Predict the labels for a batch of instances.
+
+        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
+            ``(batch_size, num_features)``
+        :return: Predicted batch of :py:attr:`y_dtype` valued labels
+            ``(batch_size,)``.
+        """
+        return self.batch_predict_proba(x).argmax(1).to(self.device, self.y_dtype)
+
+    def train(self, instance: LabeledInstance) -> None:
+        """Calls :func:`batch_train` with a batch of size 1."""
+        x = torch.from_numpy(instance.x).view(1, -1)
+        x = x.to(self.device, self.x_dtype)
+        y = torch.scalar_tensor(
+            instance.y_index, dtype=self.y_dtype, device=self.device
+        ).view(1)
+        return self.batch_train(x, y)
+
+    def predict_proba(self, instance: Instance) -> Optional[LabelProbabilities]:
+        """Calls :func:`batch_predict_proba` with a batch of size 1."""
+        x = torch.from_numpy(instance.x.reshape(1, -1))
+        x = x.to(self.device, self.x_dtype)
+        return self.batch_predict_proba(x).flatten().numpy().astype(np.float64)

--- a/src/capymoa/base/_batch_regressor.py
+++ b/src/capymoa/base/_batch_regressor.py
@@ -1,0 +1,124 @@
+"""Batch regressor base class.
+
+Separated from :mod:`capymoa.base._regressor` so that importing
+:mod:`capymoa.base` does not import PyTorch. :class:`BatchRegressor` cannot work
+without PyTorch, so it is exposed lazily from :mod:`capymoa.base`.
+"""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from capymoa.instance import RegressionInstance
+from capymoa.type_alias import TargetValue
+
+from ._batch import Batch
+from ._regressor import Regressor
+
+
+class BatchRegressor(Regressor, Batch, ABC):
+    """Base class for regressor that support mini-batches.
+
+    Supported by:
+
+    - :func:`capymoa.evaluation.prequential_evaluation`
+
+    Evaluators that support batch classifiers will call the :func:`batch_train`
+    and :func:`batch_predict` methods instead of :func:`train` and
+    :func:`predict`:
+
+    >>> from capymoa.base import BatchRegressor
+    >>> from capymoa.datasets import FriedTiny
+    >>> from capymoa.evaluation import prequential_evaluation
+    >>>
+    >>> batch_size = 500
+    >>> class MyBatchRegressor(BatchRegressor):
+    ...     def batch_train(self, x, y):
+    ...         print(f"batch_train x: {x.shape} {x.dtype}")
+    ...         print(f"batch_train y: {y.shape} {y.dtype}")
+    ...
+    ...     def batch_predict(self, x):
+    ...         print(f"batch_predict x: {x.shape} {x.dtype}")
+    ...         return np.zeros((x.shape[0],))
+    ...
+    >>> stream = FriedTiny()
+    >>> learner = MyBatchRegressor(stream.get_schema())
+    >>> _ = prequential_evaluation(
+    ...     stream,
+    ...     learner,
+    ...     batch_size=batch_size,
+    ...     max_instances=721
+    ... )
+    batch_predict x: torch.Size([500, 10]) torch.float32
+    batch_train x: torch.Size([500, 10]) torch.float32
+    batch_train y: torch.Size([500]) torch.float32
+    batch_predict x: torch.Size([221, 10]) torch.float32
+    batch_train x: torch.Size([221, 10]) torch.float32
+    batch_train y: torch.Size([221]) torch.float32
+
+    You can manually use ``itertools.batched`` (python 3.12) function and
+    ``np.stack`` to collect batches of instances as a matrix:
+
+    >>> from itertools import islice
+    >>> from capymoa._utils import batched # Not available in python < 3.12
+    >>> for i, batch in enumerate(batched(stream, 100)):
+    ...     x = np.stack([instance.x for instance in batch])
+    ...     y = np.stack([instance.y_value for instance in batch])
+    ...     x = torch.from_numpy(x).to(dtype=learner.x_dtype, device=learner.device)
+    ...     y = torch.from_numpy(y).to(dtype=learner.y_dtype, device=learner.device)
+    ...     learner.batch_train(x, y)
+    ...     break
+    batch_train x: torch.Size([100, 10]) torch.float32
+    batch_train y: torch.Size([100]) torch.float32
+
+    The default implementation of :func:`train` and :func:`predict` calls the
+    batch variants with a batch of size 1. This is useful for parts of CapyMOA
+    that expect a classifier to be able to train and predict on single
+    instances.
+
+    >>> instance = next(stream)
+    >>> learner.train(instance)
+    batch_train x: torch.Size([1, 10]) torch.float32
+    batch_train y: torch.Size([]) torch.float32
+    >>> learner.predict(instance)
+    batch_predict x: torch.Size([1, 10]) torch.float64
+    np.float64(0.0)
+    """
+
+    x_dtype: torch.dtype = torch.float32
+    y_dtype: torch.dtype = torch.float32
+
+    @abstractmethod
+    def batch_train(self, x: Tensor, y: Tensor) -> None:
+        """Train the classifier with a batch of instances.
+
+        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
+            ``(batch_size, num_features)``
+        :param y: Batch of :py:attr:`y_dtype` valued targets ``(batch_size,)``.
+        """
+
+    @abstractmethod
+    def batch_predict(self, x: Tensor) -> Tensor:
+        """Return probability estimates for each label in a batch.
+
+        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
+            ``(batch_size, num_features)``
+        :return: Predicted batch of :py:attr:`y_dtype` valued targets
+            ``(batch_size,)``.
+        """
+
+    def train(self, instance: RegressionInstance) -> None:
+        """Calls :func:`batch_train` with a batch of size 1."""
+        x_ = torch.from_numpy(instance.x.reshape(1, -1))
+        x_ = x_.to(dtype=self.x_dtype, device=self.device)
+        y_ = torch.scalar_tensor(
+            instance.y_value, dtype=self.y_dtype, device=self.device
+        )
+        return self.batch_train(x_, y_)
+
+    def predict(self, instance: RegressionInstance) -> TargetValue:
+        """Calls :func:`batch_predict` with a batch of size 1."""
+        x_ = torch.from_numpy(instance.x.reshape(1, -1))
+        return np.float64(self.batch_predict(x_).item())

--- a/src/capymoa/base/_classifier.py
+++ b/src/capymoa/base/_classifier.py
@@ -2,15 +2,12 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import numpy as np
-import torch
 from jpype import _jpype
 from sklearn.base import ClassifierMixin as _SKClassifierMixin
 
 from capymoa.instance import Instance, LabeledInstance
 from capymoa.stream._stream import Schema
 from capymoa.type_alias import LabelIndex, LabelProbabilities
-
-from ._batch import Batch
 
 
 class Classifier(ABC):
@@ -69,128 +66,6 @@ class Classifier(ABC):
         """
         prediction = self.predict_proba(instance)
         return int(np.argmax(prediction)) if prediction is not None else None
-
-
-class BatchClassifier(Classifier, Batch, ABC):
-    """Base class for classifiers that support mini-batches.
-
-    Supported by:
-
-    - :func:`capymoa.ocl.evaluation.ocl_train_eval_loop`
-    - :func:`capymoa.evaluation.prequential_evaluation`
-
-    Evaluators that support batch classifiers will call the :func:`batch_train`
-    and :func:`batch_predict_proba` methods instead of :func:`train` and
-    :func:`predict_proba`:
-
-    >>> from capymoa.base import BatchClassifier
-    >>> from capymoa.datasets import ElectricityTiny
-    >>> from capymoa.evaluation import prequential_evaluation
-    >>>
-    >>> batch_size = 500
-    >>> class MyBatchClassifier(BatchClassifier):
-    ...     def batch_train(self, x, y):
-    ...         print(f"batch_train x: {x.shape} {x.dtype}")
-    ...         print(f"batch_train y: {y.shape} {y.dtype}")
-    ...
-    ...     def batch_predict_proba(self, x):
-    ...         print(f"batch_predict_proba x: {x.shape} {x.dtype}")
-    ...         return torch.zeros((x.shape[0], self.schema.get_num_classes()))
-    ...
-    >>> stream = ElectricityTiny()
-    >>> learner = MyBatchClassifier(stream.get_schema())
-    >>> _ = prequential_evaluation(
-    ...     stream,
-    ...     learner,
-    ...     batch_size=batch_size,
-    ...     max_instances=721
-    ... )
-    batch_predict_proba x: torch.Size([500, 6]) torch.float32
-    batch_train x: torch.Size([500, 6]) torch.float32
-    batch_train y: torch.Size([500]) torch.int64
-    batch_predict_proba x: torch.Size([221, 6]) torch.float32
-    batch_train x: torch.Size([221, 6]) torch.float32
-    batch_train y: torch.Size([221]) torch.int64
-
-    You can manually use ``itertools.batched`` (python 3.12) function and
-    ``np.stack`` to collect batches of instances as a matrix:
-
-    >>> from itertools import islice
-    >>> from capymoa._utils import batched # Not available in python < 3.12
-    >>> stream.restart() # streams are stateful, so restart it
-    >>> for i, batch in enumerate(batched(stream, 100)):
-    ...     x = np.stack([instance.x for instance in batch])
-    ...     y = np.stack([instance.y_index for instance in batch])
-    ...     x = torch.from_numpy(x).to(learner.device, learner.x_dtype)
-    ...     y = torch.from_numpy(y).to(learner.device, learner.y_dtype)
-    ...     learner.batch_train(x, y)
-    ...     break
-    batch_train x: torch.Size([100, 6]) torch.float32
-    batch_train y: torch.Size([100]) torch.int64
-
-    The default implementation of :func:`train` and :func:`predict` calls the
-    batch variants with a batch of size 1. This is useful for parts of CapyMOA
-    that expect a classifier to be able to train and predict on single
-    instances.
-
-    >>> instance = next(stream)
-    >>> learner.train(instance)
-    batch_train x: torch.Size([1, 6]) torch.float32
-    batch_train y: torch.Size([1]) torch.int64
-    >>> learner.predict(instance)
-    batch_predict_proba x: torch.Size([1, 6]) torch.float32
-    0
-    >>> learner.predict_proba(instance)
-    batch_predict_proba x: torch.Size([1, 6]) torch.float32
-    array([0., 0.])
-    """
-
-    x_dtype: torch.dtype = torch.float32
-    y_dtype: torch.dtype = torch.int64
-
-    @abstractmethod
-    def batch_train(self, x: torch.Tensor, y: torch.Tensor) -> None:
-        """Train with a batch of instances.
-
-        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
-            ``(batch_size, num_features)``
-        :param y: Batch of :py:attr:`y_dtype` valued labels ``(batch_size,)``.
-        """
-
-    @abstractmethod
-    def batch_predict_proba(self, x: torch.Tensor) -> torch.Tensor:
-        """Predict the probabilities of the classes for a batch of instances.
-
-        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
-            ``(batch_size, num_features)``
-        :return: Batch of :py:attr:`x_dtype` valued predicted probabilities
-            ``(batch_size, num_classes)``.
-        """
-
-    def batch_predict(self, x: torch.Tensor) -> torch.Tensor:
-        """Predict the labels for a batch of instances.
-
-        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
-            ``(batch_size, num_features)``
-        :return: Predicted batch of :py:attr:`y_dtype` valued labels
-            ``(batch_size,)``.
-        """
-        return self.batch_predict_proba(x).argmax(1).to(self.device, self.y_dtype)
-
-    def train(self, instance: LabeledInstance) -> None:
-        """Calls :func:`batch_train` with a batch of size 1."""
-        x = torch.from_numpy(instance.x).view(1, -1)
-        x = x.to(self.device, self.x_dtype)
-        y = torch.scalar_tensor(
-            instance.y_index, dtype=self.y_dtype, device=self.device
-        ).view(1)
-        return self.batch_train(x, y)
-
-    def predict_proba(self, instance: Instance) -> Optional[LabelProbabilities]:
-        """Calls :func:`batch_predict_proba` with a batch of size 1."""
-        x = torch.from_numpy(instance.x.reshape(1, -1))
-        x = x.to(self.device, self.x_dtype)
-        return self.batch_predict_proba(x).flatten().numpy().astype(np.float64)
 
 
 class MOAClassifier(Classifier):

--- a/src/capymoa/base/_regressor.py
+++ b/src/capymoa/base/_regressor.py
@@ -1,15 +1,10 @@
 from abc import ABC, abstractmethod
 
-import numpy as np
-import torch
 from sklearn.base import RegressorMixin as _SKRegressorMixin
-from torch import Tensor
 
 from capymoa.instance import Instance, RegressionInstance
 from capymoa.stream._stream import Schema
 from capymoa.type_alias import TargetValue
-
-from ._batch import Batch
 
 
 class Regressor(ABC):
@@ -27,112 +22,6 @@ class Regressor(ABC):
     @abstractmethod
     def predict(self, instance: RegressionInstance) -> TargetValue:
         pass
-
-
-class BatchRegressor(Regressor, Batch, ABC):
-    """Base class for regressor that support mini-batches.
-
-    Supported by:
-
-    - :func:`capymoa.evaluation.prequential_evaluation`
-
-    Evaluators that support batch classifiers will call the :func:`batch_train`
-    and :func:`batch_predict` methods instead of :func:`train` and
-    :func:`predict`:
-
-    >>> from capymoa.base import BatchRegressor
-    >>> from capymoa.datasets import FriedTiny
-    >>> from capymoa.evaluation import prequential_evaluation
-    >>>
-    >>> batch_size = 500
-    >>> class MyBatchRegressor(BatchRegressor):
-    ...     def batch_train(self, x, y):
-    ...         print(f"batch_train x: {x.shape} {x.dtype}")
-    ...         print(f"batch_train y: {y.shape} {y.dtype}")
-    ...
-    ...     def batch_predict(self, x):
-    ...         print(f"batch_predict x: {x.shape} {x.dtype}")
-    ...         return np.zeros((x.shape[0],))
-    ...
-    >>> stream = FriedTiny()
-    >>> learner = MyBatchRegressor(stream.get_schema())
-    >>> _ = prequential_evaluation(
-    ...     stream,
-    ...     learner,
-    ...     batch_size=batch_size,
-    ...     max_instances=721
-    ... )
-    batch_predict x: torch.Size([500, 10]) torch.float32
-    batch_train x: torch.Size([500, 10]) torch.float32
-    batch_train y: torch.Size([500]) torch.float32
-    batch_predict x: torch.Size([221, 10]) torch.float32
-    batch_train x: torch.Size([221, 10]) torch.float32
-    batch_train y: torch.Size([221]) torch.float32
-
-    You can manually use ``itertools.batched`` (python 3.12) function and
-    ``np.stack`` to collect batches of instances as a matrix:
-
-    >>> from itertools import islice
-    >>> from capymoa._utils import batched # Not available in python < 3.12
-    >>> for i, batch in enumerate(batched(stream, 100)):
-    ...     x = np.stack([instance.x for instance in batch])
-    ...     y = np.stack([instance.y_value for instance in batch])
-    ...     x = torch.from_numpy(x).to(dtype=learner.x_dtype, device=learner.device)
-    ...     y = torch.from_numpy(y).to(dtype=learner.y_dtype, device=learner.device)
-    ...     learner.batch_train(x, y)
-    ...     break
-    batch_train x: torch.Size([100, 10]) torch.float32
-    batch_train y: torch.Size([100]) torch.float32
-
-    The default implementation of :func:`train` and :func:`predict` calls the
-    batch variants with a batch of size 1. This is useful for parts of CapyMOA
-    that expect a classifier to be able to train and predict on single
-    instances.
-
-    >>> instance = next(stream)
-    >>> learner.train(instance)
-    batch_train x: torch.Size([1, 10]) torch.float32
-    batch_train y: torch.Size([]) torch.float32
-    >>> learner.predict(instance)
-    batch_predict x: torch.Size([1, 10]) torch.float64
-    np.float64(0.0)
-    """
-
-    x_dtype: torch.dtype = torch.float32
-    y_dtype: torch.dtype = torch.float32
-
-    @abstractmethod
-    def batch_train(self, x: Tensor, y: Tensor) -> None:
-        """Train the classifier with a batch of instances.
-
-        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
-            ``(batch_size, num_features)``
-        :param y: Batch of :py:attr:`y_dtype` valued targets ``(batch_size,)``.
-        """
-
-    @abstractmethod
-    def batch_predict(self, x: Tensor) -> Tensor:
-        """Return probability estimates for each label in a batch.
-
-        :param x: Batch of :py:attr:`x_dtype` valued feature vectors
-            ``(batch_size, num_features)``
-        :return: Predicted batch of :py:attr:`y_dtype` valued targets
-            ``(batch_size,)``.
-        """
-
-    def train(self, instance: RegressionInstance) -> None:
-        """Calls :func:`batch_train` with a batch of size 1."""
-        x_ = torch.from_numpy(instance.x.reshape(1, -1))
-        x_ = x_.to(dtype=self.x_dtype, device=self.device)
-        y_ = torch.scalar_tensor(
-            instance.y_value, dtype=self.y_dtype, device=self.device
-        )
-        return self.batch_train(x_, y_)
-
-    def predict(self, instance: RegressionInstance) -> TargetValue:
-        """Calls :func:`batch_predict` with a batch of size 1."""
-        x_ = torch.from_numpy(instance.x.reshape(1, -1))
-        return np.float64(self.batch_predict(x_).item())
 
 
 class MOARegressor(Regressor):

--- a/src/capymoa/classifier/__init__.py
+++ b/src/capymoa/classifier/__init__.py
@@ -1,3 +1,4 @@
+from capymoa._optional import lazy_torch_attrs
 from ._adaptive_random_forest import AdaptiveRandomForestClassifier
 from ._efdt import EFDT
 from ._hoeffding_tree import HoeffdingTree
@@ -21,7 +22,6 @@ from ._dynamic_weighted_majority import DynamicWeightedMajority
 from ._csmote import CSMOTE
 from ._weightedknn import WeightedkNN
 from ._shrubs_classifier import ShrubsClassifier
-from ._finetune import Finetune
 from ._dems import DynamicEnsembleMemberSelection
 from ._plastic import PLASTIC
 
@@ -53,3 +53,12 @@ __all__ = [
     "DynamicEnsembleMemberSelection",
     "PLASTIC",
 ]
+
+
+#: Names that need PyTorch. Imported on first access so ``import capymoa`` stays
+#: torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "Finetune": "._finetune",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "Finetune", __all__)

--- a/src/capymoa/datasets/_torch_utils.py
+++ b/src/capymoa/datasets/_torch_utils.py
@@ -1,0 +1,42 @@
+"""Dataset helpers that require PyTorch.
+
+Separated from :mod:`capymoa.datasets._utils` so that importing
+:mod:`capymoa.datasets` does not import PyTorch, which is an optional extra.
+Only :mod:`capymoa.ocl.datasets` uses these, and OCL requires PyTorch anyway.
+"""
+
+from typing import Callable, Optional, Tuple
+
+import torch
+
+
+class TensorDatasetWithTransform(
+    torch.utils.data.Dataset[Tuple[torch.Tensor, torch.Tensor]]
+):
+    """A PyTorch dataset that applies a transformation to the data."""
+
+    def __init__(
+        self,
+        data: torch.Tensor,
+        targets: torch.Tensor,
+        transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        target_transform: Optional[Callable[[object], object]] = None,
+    ):
+        self.data = data
+        self.targets = targets
+        self.transform = transform
+        self.target_transform = target_transform
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        x = self.data[idx]
+        y = self.targets[idx]
+
+        if self.transform:
+            x = self.transform(x)
+        if self.target_transform:
+            y = self.target_transform(y)
+
+        return x, y

--- a/src/capymoa/datasets/_utils.py
+++ b/src/capymoa/datasets/_utils.py
@@ -1,8 +1,7 @@
 import gzip
 from pathlib import Path
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 from urllib.request import urlretrieve
-import torch
 from shutil import copyfileobj
 from capymoa.env import capymoa_datasets_dir
 import numpy as np
@@ -156,35 +155,3 @@ def download_numpy_dataset(
             np.load(path / "test_y.npy"),
         ),
     )
-
-
-class TensorDatasetWithTransform(
-    torch.utils.data.Dataset[Tuple[torch.Tensor, torch.Tensor]]
-):
-    """A PyTorch dataset that applies a transformation to the data."""
-
-    def __init__(
-        self,
-        data: torch.Tensor,
-        targets: torch.Tensor,
-        transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
-        target_transform: Optional[Callable[[object], object]] = None,
-    ):
-        self.data = data
-        self.targets = targets
-        self.transform = transform
-        self.target_transform = target_transform
-
-    def __len__(self):
-        return len(self.data)
-
-    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
-        x = self.data[idx]
-        y = self.targets[idx]
-
-        if self.transform:
-            x = self.transform(x)
-        if self.target_transform:
-            y = self.target_transform(y)
-
-        return x, y

--- a/src/capymoa/drift/detectors/__init__.py
+++ b/src/capymoa/drift/detectors/__init__.py
@@ -1,4 +1,4 @@
-from .abcd import ABCD
+from capymoa._optional import lazy_torch_attrs
 from .adwin import ADWIN
 from .cusum import CUSUM
 from .ddm import DDM
@@ -29,3 +29,14 @@ __all__ = [
     "STEPD",
     "STUDD",
 ]
+
+
+#: ABCD uses a torch autoencoder. Imported on first access so ``import capymoa``
+#: stays torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "ABCD": ".abcd",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(
+    __name__, _LAZY, "the ABCD drift detector", __all__
+)

--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -5,10 +5,9 @@ import time
 import warnings
 from collections import deque
 from itertools import islice
+import sys
 from typing import Any, Deque, Optional, Sized, Tuple, Union
 
-from capymoa.base import Batch
-import torch
 import numpy as np
 import pandas as pd
 from com.yahoo.labs.samoa.instances import Attribute, DenseInstance, Instances
@@ -31,8 +30,6 @@ from tqdm import tqdm
 from capymoa._utils import _translate_metric_name, batched
 from capymoa.base import (
     AnomalyDetector,
-    BatchClassifier,
-    BatchRegressor,
     Classifier,
     ClassifierSSL,
     Clusterer,
@@ -923,6 +920,33 @@ def stop_time_measuring(start_wallclock_time, start_cpu_time):
     return elapsed_wallclock_time, elapsed_cpu_time
 
 
+def _batch_learner_class(name: str):
+    """Return a ``capymoa.base`` batch class, or ``None`` if torch is absent.
+
+    These classes require PyTorch, which is an optional extra. An instance of
+    one cannot exist unless its module has already been imported, so checking
+    :data:`sys.modules` lets evaluation support batch learners without dragging
+    torch into a torch-free install.
+    """
+    module = sys.modules.get(_BATCH_MODULES[name])
+    return getattr(module, name, None) if module is not None else None
+
+
+_BATCH_MODULES = {
+    "Batch": "capymoa.base._batch",
+    "BatchClassifier": "capymoa.base._batch_classifier",
+    "BatchRegressor": "capymoa.base._batch_regressor",
+}
+
+
+def _isinstance_batch(learner, *names: str) -> bool:
+    """``isinstance`` against batch classes, without importing torch."""
+    classes = tuple(
+        cls for cls in (_batch_learner_class(name) for name in names) if cls is not None
+    )
+    return bool(classes) and isinstance(learner, classes)
+
+
 def _get_target(
     instance: Union[LabeledInstance, RegressionInstance],
 ) -> Union[int, np.double]:
@@ -977,7 +1001,9 @@ def prequential_evaluation(
     """
     if restart_stream:
         stream.restart()
-    if batch_size != 1 and not isinstance(learner, (BatchClassifier, BatchRegressor)):
+    if batch_size != 1 and not _isinstance_batch(
+        learner, "BatchClassifier", "BatchRegressor"
+    ):
         raise ValueError(
             "The learner is not a batch learner, but mini_batch is set to a value greater than 1."
         )
@@ -1038,8 +1064,10 @@ def prequential_evaluation(
         yb_true = [_get_target(instance) for instance in batch]  # batch of targets
         yb_pred = []
 
-        if isinstance(learner, Batch):
+        if _isinstance_batch(learner, "Batch"):
             # Collect a batch of instances and predict them all at once
+            import torch  # optional extra; a Batch learner guarantees it
+
             np_x = np.stack([instance.x for instance in batch])
             torch_x = torch.from_numpy(np_x).to(
                 device=learner.device, dtype=learner.x_dtype

--- a/src/capymoa/exception.py
+++ b/src/capymoa/exception.py
@@ -3,3 +3,47 @@ class StreamTypeError(Exception):
 
     For example, when a classification stream is used in a regression task.
     """
+
+
+class OptionalDependencyError(ImportError):
+    """Raised when a feature needs an optional dependency that is not installed.
+
+    CapyMOA keeps heavyweight dependencies out of the default installation. This
+    error tells the user exactly which feature they reached for and how to
+    install what it needs.
+
+    >>> from capymoa.exception import OptionalDependencyError
+    >>> raise OptionalDependencyError("PyTorch", "capymoa.ocl")
+    Traceback (most recent call last):
+        ...
+    capymoa.exception.OptionalDependencyError: PyTorch is required for capymoa.ocl.
+    Install it with: pip install capymoa[torch]
+    """
+
+    def __init__(self, dependency: str = "PyTorch", feature: str = "this feature"):
+        self._dependency = dependency
+        self._feature = feature
+        super().__init__(
+            f"{dependency} is required for {feature}.\n"
+            f"Install it with: pip install capymoa[torch]"
+        )
+
+
+def _requires_torch(feature: str) -> None:
+    """Raise :class:`OptionalDependencyError` if PyTorch is not installed.
+
+    Call this at the top of a lazy import path so the user gets an actionable
+    message instead of a bare ``ModuleNotFoundError: No module named 'torch'``.
+
+    :param feature: What the user was trying to use, e.g. ``"capymoa.ocl"``.
+    """
+    from importlib.util import find_spec
+
+    try:
+        found = find_spec("torch") is not None
+    except (ImportError, ValueError):
+        # A finder may raise rather than return None when torch is absent or
+        # deliberately blocked (see tests/test_no_torch.py).
+        found = False
+    if not found:
+        raise OptionalDependencyError("PyTorch", feature)

--- a/src/capymoa/ocl/__init__.py
+++ b/src/capymoa/ocl/__init__.py
@@ -52,6 +52,14 @@ Forward Transfer: 0.03
 Backward Transfer: -0.07
 """
 
-from . import base, datasets, evaluation, util, strategy
+# PyTorch is an optional extra; this whole module requires it.
+try:
+    from . import base, datasets, evaluation, util, strategy
+except ModuleNotFoundError as _err:  # pragma: no cover
+    if (_err.name or "").split(".")[0] in ("torch", "torchvision"):
+        from capymoa.exception import OptionalDependencyError
+
+        raise OptionalDependencyError("PyTorch", "capymoa.ocl") from _err
+    raise
 
 __all__ = ["evaluation", "datasets", "strategy", "base", "util"]

--- a/src/capymoa/ocl/datasets/_tiny.py
+++ b/src/capymoa/ocl/datasets/_tiny.py
@@ -5,7 +5,8 @@ import torch
 from torch import Tensor
 from torch.utils.data import Dataset
 
-from capymoa.datasets._utils import TensorDatasetWithTransform, download_numpy_dataset
+from capymoa.datasets._torch_utils import TensorDatasetWithTransform
+from capymoa.datasets._utils import download_numpy_dataset
 
 from ._base import _BuiltInCIScenario, _BuiltInRotatedDomainScenario
 from ._constants import _SOURCES

--- a/src/capymoa/ocl/datasets/_vit.py
+++ b/src/capymoa/ocl/datasets/_vit.py
@@ -6,7 +6,8 @@ from torch import Tensor
 from torch.utils.data import ConcatDataset, Dataset, Subset
 
 from capymoa.datasets import get_download_dir
-from capymoa.datasets._utils import TensorDatasetWithTransform, download_numpy_dataset
+from capymoa.datasets._torch_utils import TensorDatasetWithTransform
+from capymoa.datasets._utils import download_numpy_dataset
 from capymoa.ocl.util.data import group_indicies
 from capymoa.stream import TorchStream
 

--- a/src/capymoa/ssl/__init__.py
+++ b/src/capymoa/ssl/__init__.py
@@ -1,4 +1,13 @@
-from ._osnn import OSNN
+from capymoa._optional import lazy_torch_attrs
 from ._sleade import SLEADE
 
 __all__ = ["OSNN", "SLEADE"]
+
+
+#: Names that need PyTorch. Imported on first access so ``import capymoa`` stays
+#: torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "OSNN": "._osnn",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "OSNN", __all__)

--- a/src/capymoa/stream/__init__.py
+++ b/src/capymoa/stream/__init__.py
@@ -1,3 +1,4 @@
+from capymoa._optional import lazy_torch_attrs
 from ._stream import (
     Stream,
     Schema,
@@ -7,7 +8,6 @@ from ._stream import (
 )
 from ._csv_stream import CSVStream
 from ._stream_from_file import stream_from_file
-from .torch import TorchStream
 from . import drift, generator, preprocessing
 
 __all__ = [
@@ -23,3 +23,12 @@ __all__ = [
     "MOAStream",
     "stream_from_file",
 ]
+
+
+#: Names that need PyTorch. Imported on first access so ``import capymoa`` stays
+#: torch-free -- see :mod:`capymoa._optional`.
+_LAZY = {
+    "TorchStream": ".torch",
+}
+
+__getattr__, __dir__ = lazy_torch_attrs(__name__, _LAZY, "TorchStream", __all__)

--- a/tests/test_no_torch.py
+++ b/tests/test_no_torch.py
@@ -120,3 +120,68 @@ def test_torch_backed_names_still_work_when_torch_present():
     assert all(
         isinstance(cls, type) for cls in (Batch, BatchClassifier, BatchRegressor)
     )
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "capymoa.base",
+        "capymoa.classifier",
+        "capymoa.stream",
+        "capymoa.anomaly",
+        "capymoa.ssl",
+        "capymoa.drift.detectors",
+    ],
+)
+def test_wildcard_import_without_torch(module: str):
+    """``import *`` must not drag in torch-only names.
+
+    ``__all__`` drives ``from package import *``. If the lazy names stayed
+    listed, a wildcard import would resolve every torch-backed name and fail
+    even for a user who only wanted the core ones.
+    """
+    result = _run_without_torch(f"""
+        from {module} import *  # noqa: F401,F403
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_all_drops_lazy_names_without_torch():
+    """Without torch, ``__all__`` advertises only what can actually be imported."""
+    result = _run_without_torch("""
+        import capymoa.base as base
+        import capymoa.classifier as classifier
+
+        for name in ("Batch", "BatchClassifier", "BatchRegressor"):
+            assert name not in base.__all__, name
+        assert "Finetune" not in classifier.__all__
+
+        # Core names are untouched.
+        assert "Classifier" in base.__all__
+        assert "HoeffdingTree" in classifier.__all__
+
+        # And the names are still reachable by explicit import, with a
+        # helpful error rather than silence.
+        from capymoa.exception import OptionalDependencyError
+        try:
+            base.BatchClassifier
+        except OptionalDependencyError:
+            print("OK")
+        else:
+            raise AssertionError("expected OptionalDependencyError")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_all_keeps_lazy_names_when_torch_present():
+    """With torch installed ``__all__`` is unfiltered, so docs stay complete."""
+    pytest.importorskip("torch")
+    import capymoa.base as base
+    import capymoa.classifier as classifier
+
+    for name in ("Batch", "BatchClassifier", "BatchRegressor"):
+        assert name in base.__all__, name
+    assert "Finetune" in classifier.__all__

--- a/tests/test_no_torch.py
+++ b/tests/test_no_torch.py
@@ -1,0 +1,122 @@
+"""Guard the torch-free import path.
+
+PyTorch is an optional extra (``pip install capymoa[torch]``). The core of
+CapyMOA must import and run without it, otherwise ``pip install capymoa`` has to
+keep pulling the CUDA stack -- ~2.9 GB on Linux.
+
+These tests simulate PyTorch being absent by blocking it on ``sys.meta_path``,
+so they run in the normal CI matrix without needing a separate torch-free
+environment. They are the regression guard: the first time someone adds a
+top-level ``import torch`` to a core module, this fails.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+#: Prelude that makes ``import torch`` fail, as it would without the extra.
+_BLOCK_TORCH = """
+import sys
+
+class _BlockTorch:
+    def find_spec(self, name, path=None, target=None):
+        if name == "torch" or name.startswith(("torch.", "torchvision")):
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        return None
+
+sys.meta_path.insert(0, _BlockTorch())
+"""
+
+
+def _run_without_torch(body: str) -> subprocess.CompletedProcess:
+    """Run ``body`` in a subprocess where importing torch fails."""
+    script = _BLOCK_TORCH + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_capymoa_without_torch():
+    """``import capymoa`` must not need PyTorch."""
+    result = _run_without_torch("""
+        import capymoa
+        import sys
+        assert "torch" not in sys.modules, "capymoa imported torch"
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "capymoa.base",
+        "capymoa.classifier",
+        "capymoa.regressor",
+        "capymoa.stream",
+        "capymoa.datasets",
+        "capymoa.evaluation",
+        "capymoa.drift",
+        "capymoa.anomaly",
+        "capymoa.ssl",
+    ],
+)
+def test_core_modules_import_without_torch(module: str):
+    """Every core package must import without PyTorch."""
+    result = _run_without_torch(f"""
+        import sys
+        import {module}
+        assert "torch" not in sys.modules, "{module} imported torch"
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_classification_loop_without_torch():
+    """The core stream-learning path must work without PyTorch."""
+    result = _run_without_torch("""
+        from capymoa.classifier import AdaptiveRandomForestClassifier
+        from capymoa.datasets import ElectricityTiny
+        from capymoa.evaluation import prequential_evaluation
+
+        stream = ElectricityTiny()
+        learner = AdaptiveRandomForestClassifier(schema=stream.get_schema())
+        results = prequential_evaluation(stream, learner, max_instances=1000)
+        assert results["cumulative"].accuracy() > 50
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_torch_backed_name_raises_helpful_error():
+    """Reaching a torch-only feature explains how to install it."""
+    result = _run_without_torch("""
+        from capymoa.exception import OptionalDependencyError
+        try:
+            from capymoa.base import BatchClassifier  # noqa: F401
+        except OptionalDependencyError as err:
+            assert "PyTorch is required" in str(err), err
+            assert "pip install capymoa[torch]" in str(err), err
+            print("OK")
+        else:
+            raise AssertionError("expected OptionalDependencyError")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_torch_backed_names_still_work_when_torch_present():
+    """With the extra installed, the public API is unchanged."""
+    pytest.importorskip("torch")
+    from capymoa.base import Batch, BatchClassifier, BatchRegressor
+
+    assert all(
+        isinstance(cls, type) for cls in (Batch, BatchClassifier, BatchRegressor)
+    )


### PR DESCRIPTION
Closes #371.

## What and why

`pip install capymoa` pulled `torch` and `torchvision` as hard dependencies. On Linux that resolves the default PyPI PyTorch wheel, which is CUDA-enabled, so **every** user downloaded ~2.9 GB across 16 nvidia/triton packages — including someone who just wants a Hoeffding tree on a CSV. Nothing on the core stream-learning path uses it.

PyTorch is now the `capymoa[torch]` extra.

| | before | after |
|---|---|---|
| packages from a bare install | 34 (16 nvidia/triton) | **27 (0 nvidia/triton)** |
| `import capymoa` | loads 769 torch submodules | **loads none** |
| `import capymoa` time | 1.64 s | **1.00 s** |

## This is not just a `pyproject.toml` change

The core import path had to stop importing torch. Type annotations were the easy part; **class bodies** were the blocker, since they execute at import:

```python
x_dtype: torch.dtype = torch.float32          # base/_classifier.py
device: torch.device = torch.device("cpu")    # base/_batch.py
```

No `TYPE_CHECKING` guard helps there, so the torch-backed classes move behind a lazy boundary:

- `BatchClassifier` / `BatchRegressor` split out of `_classifier.py` / `_regressor.py` into their own modules, leaving `Classifier`, `MOAClassifier`, `SKClassifier`, `Regressor` and friends torch-free.
- `TensorDatasetWithTransform` moved to `datasets/_torch_utils.py`. Only `capymoa.ocl` uses it, and OCL requires torch anyway.
- Torch-backed public names — `Batch*`, `Finetune`, `Autoencoder`, `OSNN`, `TorchStream`, `ABCD` — are re-exported lazily via :pep:`562` module `__getattr__` (`capymoa/_optional.py`).
- `evaluation.py` detects batch learners through `sys.modules` instead of importing them: a `Batch` instance cannot exist unless its module is already loaded.
- `capymoa.ocl` and `capymoa.ann` need torch wholesale and raise `OptionalDependencyError` naming the install command.

## Not a breaking API change

`from capymoa.classifier import Finetune` still works verbatim when torch is installed — the lazy re-export is transparent. Without torch you get:

```
OptionalDependencyError: PyTorch is required for capymoa.ocl.
Install it with: pip install capymoa[torch]
```

instead of a bare `ModuleNotFoundError`. Existing environments are unaffected: `pip install -U capymoa` does not uninstall a torch that is already there.

## Two things found along the way

**`typing_extensions` was an undeclared dependency.** Four core modules import `override` from it, but it was only arriving transitively via torch's own `typing-extensions>=4.10.0`. Removing torch exposed it. Now declared explicitly — a latent packaging bug independent of this change.

**A lazy-export pitfall, and the reason for the `conf.py` hunk.** Overriding a module's `__dir__` to return only a curated list hides eagerly-imported names from Sphinx autosummary, which then documents classes under private module paths (`capymoa.drift.detectors.abcd.ABCD` instead of `capymoa.drift.detectors.ABCD`) and breaks every cross-reference to them — 249 nitpick failures, and since docs build with `-W -n`, a failed Documentation job. `__dir__` now unions the module's real namespace with the lazy names. The one remaining reference, the bare `Optimizer` typehint, is ignored alongside the existing `Tensor` and `nn.Module` entries, because `autodoc_typehints_format = "short"` strips the `torch.optim.optimizer` prefix.

## Wildcard imports

Raised in review: `__all__` drives `from package import *`, so listing the lazy names there made a wildcard import resolve every torch-backed name and fail in a torch-free install, even for someone who only wanted the core ones. It affected `capymoa.base`, `.classifier`, `.stream`, `.anomaly`, `.ssl` and `.drift.detectors`.

When PyTorch is missing the lazy names are now dropped from `__all__`, so `import *` yields exactly what is usable. An explicit `from capymoa.classifier import Finetune` still raises the actionable error, and with PyTorch installed `__all__` is untouched — so the public API and the generated docs are unchanged. Covered by 8 new tests and a CI step.

## Validation

New **"Install without PyTorch"** CI job installs with no extras and asserts torch is absent, `import capymoa` does not load it, a prequential ARF run works, and `capymoa.ocl` / `capymoa.ann` raise an actionable error. This is what makes the fix stick — without it the first stray top-level `import torch` silently restores the 2.9 GB install.

`tests/test_no_torch.py` blocks torch on `sys.meta_path` so the same guarantees are checked inside the normal test matrix.

Verified locally:

- pytest 190 passed, doctest 125 passed, all 18 notebooks pass, ruff clean
- `invoke docs.build` exits 0, with the same stub attribution as `main`
- a real venv with no torch installed: ARF on ElectricityTiny gives **87.9**, identical to the torch-installed run
- a **built wheel** installed with no extras: 27 packages, zero nvidia/triton, ARF 87.9

## Caveat that survives this change

`pip install capymoa[torch]` on Linux still pulls the CUDA stack, because that is what the default PyPI wheel depends on, and package metadata cannot pin an index (PEP 508 has no such field). The CPU route is now documented in the setup guide:

```bash
pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
pip install capymoa[torch]
```

## Note for reviewers

This touches `evaluation/evaluation.py`, which #356 also restructures. Merging this first means #356 needs a rebase — deliberate, since this is user-facing friction.
