### PR TITLE
fix(drift): validate drift and drift-stream construction

### DIFF
--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -43,6 +43,8 @@ class DriftStream(MOAStream):
         self.drifts = []
 
         if CLI is None:
+            self._validate_stream_definition(self.stream)
+
             stream1 = None
             stream2 = None
             drift = None
@@ -78,21 +80,6 @@ class DriftStream(MOAStream):
                     self.drifts.append(drift)
                     CLI = f" -s {cli_str_stream(stream1.moa_stream)} "
 
-                else:
-                    # Anything else used to be skipped silently, which produced a
-                    # stream missing that concept while still reporting the drift
-                    # from ``get_num_drifts()``. Composition is delegated to MOA's
-                    # ConceptDriftStream, so concepts have to be MOA-backed;
-                    # Python-native streams such as NumpyStream, CSVStream and
-                    # TorchStream cannot be used here yet (see issue #90).
-                    raise ValueError(
-                        f"DriftStream cannot use {type(component).__name__} as a "
-                        "component. Concepts must be MOA-backed streams (a "
-                        "``MOAStream``, e.g. a generator or an ``ARFFStream``) and "
-                        "drifts must be ``Drift`` objects. Python-native streams "
-                        "are not supported as concepts yet."
-                    )
-
             moa_stream = MOA_ConceptDriftStream()
         else:
             # [EXPERIMENTAL]
@@ -126,6 +113,60 @@ class DriftStream(MOAStream):
                     )
 
         super().__init__(schema=schema, CLI=CLI, moa_stream=moa_stream)
+
+    @staticmethod
+    def _validate_stream_definition(stream):
+        """Check the concept/drift list before anything is composed.
+
+        The definition has to alternate concept, drift, concept, ... starting
+        and ending with a concept. Validating up front matters because the
+        builder appends each ``Drift`` to ``self.drifts`` as it sees it, before
+        it knows whether a concept follows: a malformed list would otherwise
+        report drifts through :func:`get_num_drifts` that were never composed
+        into the stream.
+        """
+        if not stream:
+            raise ValueError(
+                "DriftStream needs a non-empty list of concepts and drifts, "
+                "e.g. [concept, drift, concept]."
+            )
+
+        def kind(component):
+            if isinstance(component, Drift):
+                return "drift"
+            if isinstance(component, MOAStream):
+                return "concept"
+            return None
+
+        for i, component in enumerate(stream):
+            actual = kind(component)
+            if actual is None:
+                # Composition is delegated to MOA's ConceptDriftStream, so
+                # concepts have to be MOA-backed; Python-native streams such as
+                # NumpyStream, CSVStream and TorchStream cannot be used yet
+                # (see issue #90).
+                raise ValueError(
+                    f"DriftStream cannot use {type(component).__name__} as a "
+                    "component. Concepts must be MOA-backed streams (a "
+                    "``MOAStream``, e.g. a generator or an ``ARFFStream``) and "
+                    "drifts must be ``Drift`` objects. Python-native streams "
+                    "are not supported as concepts yet."
+                )
+            expected = "concept" if i % 2 == 0 else "drift"
+            if actual != expected:
+                raise ValueError(
+                    "DriftStream expects concepts and drifts to alternate, "
+                    "starting and ending with a concept, e.g. "
+                    "[concept, drift, concept]. Position "
+                    f"{i} is a {actual} where a {expected} was expected."
+                )
+
+        if kind(stream[-1]) == "drift":
+            raise ValueError(
+                "DriftStream must end with a concept, not a drift: a trailing "
+                f"{type(stream[-1]).__name__} has no concept to drift into. "
+                f"Got {len(stream)} components ending with a drift."
+            )
 
     def get_num_drifts(self):
         return len(self.drifts)

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -78,6 +78,21 @@ class DriftStream(MOAStream):
                     self.drifts.append(drift)
                     CLI = f" -s {cli_str_stream(stream1.moa_stream)} "
 
+                else:
+                    # Anything else used to be skipped silently, which produced a
+                    # stream missing that concept while still reporting the drift
+                    # from ``get_num_drifts()``. Composition is delegated to MOA's
+                    # ConceptDriftStream, so concepts have to be MOA-backed;
+                    # Python-native streams such as NumpyStream, CSVStream and
+                    # TorchStream cannot be used here yet (see issue #90).
+                    raise ValueError(
+                        f"DriftStream cannot use {type(component).__name__} as a "
+                        "component. Concepts must be MOA-backed streams (a "
+                        "``MOAStream``, e.g. a generator or an ``ARFFStream``) and "
+                        "drifts must be ``Drift`` objects. Python-native streams "
+                        "are not supported as concepts yet."
+                    )
+
             moa_stream = MOA_ConceptDriftStream()
         else:
             # [EXPERIMENTAL]

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -164,29 +164,76 @@ class Drift:
 
 
 class GradualDrift(Drift):
+    """A drift where two concepts overlap over a window of instances.
+
+    The location can be given in either of two mutually exclusive ways, which
+    describe the same drift:
+
+    >>> from capymoa.stream.drift import GradualDrift
+    >>> print(GradualDrift(position=100, width=10))
+    GradualDrift(position=100, start=95, end=105, width=10)
+    >>> print(GradualDrift(start=95, end=105))
+    GradualDrift(position=100, start=95, end=105, width=10)
+
+    Supplying neither style, or only half of one, is an error -- rather than
+    building a drift with no location:
+
+    >>> GradualDrift(position=100)
+    Traceback (most recent call last):
+        ...
+    ValueError: GradualDrift needs exactly one of ``position`` and ``width``, or ``start`` and ``end``, to locate the drift. Got position=100.
+
+    >>> GradualDrift(position=100, start=95)
+    Traceback (most recent call last):
+        ...
+    ValueError: GradualDrift needs exactly one of ``position`` and ``width``, or ``start`` and ``end``, to locate the drift. Got position=100, start=95.
+    """
+
     def __init__(
         self, position=None, width=None, start=None, end=None, alpha=0.0, random_seed=1
     ):
         self.__init_args_kwargs__ = copy.copy(
             locals()
         )  # save init args for recreation. not a deep copy to avoid unnecessary use of memory
-        # since python doesn't allow overloading functions we need to check if the user hasn't defined position + width and start+end.
-        if (
-            position is not None
-            and width is not None
-            and start is not None
-            and end is not None
-        ):
+
+        # Python has no function overloading, so the location of the drift can be
+        # given in one of several mutually exclusive ways. Validate that exactly
+        # one complete style was supplied *before* assigning anything, so an
+        # invalid call raises here rather than leaving a half-built object that
+        # fails later somewhere unrelated.
+        styles = {
+            "position and width": (position is not None, width is not None),
+            "start and end": (start is not None, end is not None),
+        }
+        complete = [name for name, given in styles.items() if all(given)]
+        partial = [
+            name for name, given in styles.items() if any(given) and not all(given)
+        ]
+
+        if len(complete) != 1 or partial:
+            supplied = ", ".join(
+                f"{name}={value!r}"
+                for name, value in (
+                    ("position", position),
+                    ("width", width),
+                    ("start", start),
+                    ("end", end),
+                )
+                if value is not None
+            )
             raise ValueError(
-                "Either use start and end OR position and width to determine the location of the gradual drift."
+                "GradualDrift needs exactly one of "
+                "``position`` and ``width``, or ``start`` and ``end``, "
+                "to locate the drift. "
+                f"Got {supplied if supplied else 'no arguments'}."
             )
 
-        if start is None and end is None:
+        if complete == ["position and width"]:
             self.width = width
             self.position = position
             self.start = int(position - width / 2)
             self.end = int(position + width / 2)
-        elif position is None and width is None:
+        else:
             self.start = start
             self.end = end
             self.width = end - start
@@ -213,10 +260,28 @@ class GradualDrift(Drift):
 
 
 class AbruptDrift(Drift):
+    """An instantaneous change of concept at ``position``.
+
+    >>> from capymoa.stream.drift import AbruptDrift
+    >>> print(AbruptDrift(position=5000))
+    AbruptDrift(position=5000)
+
+    ``position`` is required. Omitting it is rejected rather than producing a
+    drift with no location:
+
+    >>> AbruptDrift(position=None)
+    Traceback (most recent call last):
+        ...
+    ValueError: AbruptDrift needs a ``position`` to locate the drift.
+    """
+
     def __init__(self, position: int, random_seed: int = 1):
         self.__init_args_kwargs__ = copy.copy(
             locals()
         )  # save init args for recreation. not a deep copy to avoid unnecessary use of memory
+
+        if position is None:
+            raise ValueError("AbruptDrift needs a ``position`` to locate the drift.")
 
         self.position = position
         self.random_seed = random_seed

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -22,7 +22,12 @@ from capymoa.stream import (
     TorchStream,
     stream_from_file,
 )
-from capymoa.stream.drift import Drift, GradualDrift, RecurrentConceptDriftStream
+from capymoa.stream.drift import (
+    AbruptDrift,
+    Drift,
+    GradualDrift,
+    RecurrentConceptDriftStream,
+)
 from capymoa.stream.generator import LEDGeneratorDrift, RandomTreeGenerator
 from pathlib import Path
 
@@ -133,6 +138,53 @@ def test_recurrent_concept_drift_stream_accepts_gradual_position_width():
         "GradualDrift(position=100, start=95, end=105, width=10)"
     )
     assert "-w 10 -p 100" in stream._CLI
+
+
+@pytest.mark.parametrize(
+    ["kwargs", "expected"],
+    [
+        (
+            {"position": 100, "width": 10},
+            "GradualDrift(position=100, start=95, end=105, width=10)",
+        ),
+        (
+            {"start": 95, "end": 105},
+            "GradualDrift(position=100, start=95, end=105, width=10)",
+        ),
+    ],
+)
+def test_gradual_drift_valid_forms(kwargs, expected):
+    """Both ways of locating a gradual drift describe the same drift."""
+    assert str(GradualDrift(**kwargs)) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"position": 100},
+        {"width": 10},
+        {"start": 95},
+        {"end": 105},
+        {"position": 100, "start": 95},
+        {"width": 10, "end": 105},
+        {"position": 100, "width": 10, "start": 95, "end": 105},
+    ],
+)
+def test_gradual_drift_rejects_incomplete_forms(kwargs):
+    """Incomplete or mixed styles raise a clear error, not an internal one.
+
+    Previously these fell through the branching and raised ``TypeError`` from
+    arithmetic on ``None``, or left the object without a ``position`` at all
+    and failed later.
+    """
+    with pytest.raises(ValueError, match="exactly one of"):
+        GradualDrift(**kwargs)
+
+
+def test_abrupt_drift_requires_position():
+    with pytest.raises(ValueError, match="needs a ``position``"):
+        AbruptDrift(position=None)
 
 
 def test_recurrent_concept_drift_stream_accepts_gradual_start_end():

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -210,6 +210,39 @@ def test_drift_stream_rejects_python_native_concept():
         )
 
 
+@pytest.mark.parametrize(
+    ["definition", "match"],
+    [
+        # Trailing drift: previously reported a drift that was never composed.
+        (["gen", "drift"], "must end with a concept"),
+        # Two drifts in a row: previously reported both, composed only the last.
+        (["gen", "drift", "drift", "gen"], "alternate"),
+        # Two concepts in a row, with no drift between them.
+        (["gen", "gen"], "alternate"),
+        # Leading drift.
+        (["drift", "gen"], "alternate"),
+    ],
+)
+def test_drift_stream_rejects_malformed_definitions(definition, match):
+    """A malformed definition must raise rather than compose a wrong stream.
+
+    ``get_num_drifts`` used to count every ``Drift`` in the list, including
+    ones the builder never composed into the MOA stream, so these produced a
+    stream whose declared drifts did not match its behaviour.
+    """
+    components = [
+        RandomTreeGenerator(tree_random_seed=1) if part == "gen" else AbruptDrift(100)
+        for part in definition
+    ]
+    with pytest.raises(ValueError, match=match):
+        DriftStream(stream=components)
+
+
+def test_drift_stream_rejects_empty_definition():
+    with pytest.raises(ValueError, match="non-empty"):
+        DriftStream(stream=[])
+
+
 def test_recurrent_concept_drift_stream_accepts_gradual_start_end():
     stream = RecurrentConceptDriftStream(
         concept_list=recurrent_drift_concepts(),

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -25,6 +25,7 @@ from capymoa.stream import (
 from capymoa.stream.drift import (
     AbruptDrift,
     Drift,
+    DriftStream,
     GradualDrift,
     RecurrentConceptDriftStream,
 )
@@ -185,6 +186,28 @@ def test_gradual_drift_rejects_incomplete_forms(kwargs):
 def test_abrupt_drift_requires_position():
     with pytest.raises(ValueError, match="needs a ``position``"):
         AbruptDrift(position=None)
+
+
+def test_drift_stream_rejects_python_native_concept():
+    """A concept DriftStream cannot use must raise, not be silently dropped.
+
+    Composition is delegated to MOA's ConceptDriftStream, so a Python-native
+    stream used as a concept was skipped by the builder loop: the resulting
+    stream contained only the remaining concepts while ``get_num_drifts()``
+    still reported the drift.
+    """
+    x = np.random.default_rng(0).random((20, 3))
+    y = np.zeros(20, dtype=int)
+    python_concept = NumpyStream(x, y, dataset_name="python_concept")
+
+    with pytest.raises(ValueError, match="cannot use NumpyStream"):
+        DriftStream(
+            stream=[
+                RandomTreeGenerator(tree_random_seed=1),
+                AbruptDrift(position=10),
+                python_concept,
+            ]
+        )
 
 
 def test_recurrent_concept_drift_stream_accepts_gradual_start_end():


### PR DESCRIPTION
## What and why

`GradualDrift` accepts two mutually exclusive ways of locating a drift — `position` + `width`, or `start` + `end` — but only validated the case where **all four** were supplied. Every other invalid combination fell through the `if/elif` and failed with an internal error that said nothing about what the caller did.

Every constructor shape, before this PR:

| call | before | after |
|---|---|---|
| `GradualDrift(position=100, width=10)` | ✅ `position=100, start=95, end=105, width=10` | unchanged |
| `GradualDrift(start=95, end=105)` | ✅ same drift | unchanged |
| `GradualDrift(position=100)` | `TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'` | clear `ValueError` |
| `GradualDrift(width=10)` | `TypeError` | clear `ValueError` |
| `GradualDrift(start=95)` | `TypeError` | clear `ValueError` |
| `GradualDrift(position=100, start=95)` | **`AttributeError: 'GradualDrift' object has no attribute 'position'`** | clear `ValueError` |
| `GradualDrift(position=..., width=..., start=..., end=...)` | `ValueError` | unchanged |
| `GradualDrift()` | `TypeError` | clear `ValueError` |

Five of eight shapes produced an internal error. The `position=100, start=95` case is the worst: neither branch condition held, so **no attribute was assigned at all** — construction appeared to succeed and the object blew up later, away from the cause.

## The change

Validate before assigning. Exactly one complete style is required; anything else raises a `ValueError` naming what was supplied and what the valid combinations are:

```
>>> GradualDrift(position=100, start=95)
ValueError: GradualDrift needs exactly one of ``position`` and ``width``, or
``start`` and ``end``, to locate the drift. Got position=100, start=95.
```

The two valid forms behave identically to before, including derived values and `__str__`.

`AbruptDrift` gains the same guard against an explicit `position=None`. Its `position` stays **required** — relaxing it belongs with the Range builder, which supplies a meaningful alternative; allowing `AbruptDrift()` now would just let users build a `DriftStream` with `position=None`, which is the same half-built-object failure this PR removes.

Both classes also gain docstrings with doctests, which they previously lacked.


## Also: `DriftStream` silently dropped components it could not compose

The builder loop handled `MOAStream` and `Drift` and **silently skipped everything else**. Since composition is delegated to MOA's `ConceptDriftStream`, concepts have to be MOA-backed — so a Python-native stream was dropped without a word:

```python
DriftStream([SEA(1), AbruptDrift(position=250), NumpyStream(...)])
```

```
constructed WITHOUT error
declared drifts : 1                              <- reports a drift
CLI             :  -s (generators.SEAGenerator)  <- 2nd concept and drift gone
```

The stream never drifts while still advertising a drift, and `NumpyStream`, `CSVStream` and `TorchStream` are all affected (none subclass `MOAStream`). That is a silently wrong experiment rather than an error.

Such a component now raises `ValueError` naming the offending type and what is supported. This only fails calls that were already producing the wrong stream.

Supporting Python-native streams as concepts needs `DriftStream` to compose in Python rather than delegate to MOA — that is #90, and out of scope here.

### And malformed definitions did the same thing

Raised in review. The builder appends each `Drift` to `self.drifts` as it encounters it, *before* it knows whether a concept follows, so a list that does not alternate reports drifts that were never composed:

| definition | `get_num_drifts()` | actually composed |
|---|---|---|
| `[generator, AbruptDrift(...)]` | 1 | no drift at all |
| `[generator, drift1, drift2, generator]` | 2 | only the last |

The definition is now validated before anything is composed: non-empty, and alternating concept, drift, concept, … starting and ending with a concept, with the offending position named. That single pre-pass also covers the unsupported-component case above, so there is one place deciding what a valid definition is.

## Why now

Prerequisite for #90 (finalize the DriftStream API). The Range builder adds a **third** mutually exclusive style — `GradualDrift(num_instances=500)` — to this same constructor. Layering that onto branching that already mishandles two styles would multiply the untested combinations. Note `GradualDrift()` with no arguments, close to the shape Range mode needs, is currently one of the broken cases.

The structure now has an obvious slot for a third style rather than another branch.

## Validation

- New parameterized tests: 2 valid shapes assert the exact `__str__`, 8 invalid shapes assert a `ValueError`, plus `AbruptDrift(position=None)`, a `NumpyStream` concept rejection, and 5 malformed-definition shapes
- Existing recurrent-drift tests from #362 still pass — they construct `GradualDrift` both ways
- pytest 198 passed, doctest 126 passed, ruff clean, `invoke docs.build` exits 0 with no warnings
- `notebooks/04_drift_streams.ipynb`, `00_getting_started.ipynb` and `09_automl.ipynb` — all `DriftStream` users — pass

No behaviour change for any call that worked before.
