### PR TITLE
fix: stop discarding predictions with small vote totals

### DIFF
--- a/src/capymoa/base/_classifier.py
+++ b/src/capymoa/base/_classifier.py
@@ -242,8 +242,13 @@ class MOAClassifier(Classifier):
 
     def predict_proba(self, instance) -> Optional[LabelProbabilities]:
         votes = np.array(self.moa_learner.getVotesForInstance(instance.java_instance))
-        total = sum(votes)
-        if total <= 1e-2 or np.isnan(total) or np.isinf(total):
+        total = votes.sum() if votes.size else 0.0
+        # MOA returns unnormalised scores, and their scale depends on the
+        # learner: majority-class leaves give integer counts, while Naive Bayes
+        # gives products of likelihoods that are routinely below 1e-2 without
+        # being any less valid. Only reject votes that carry no prediction at
+        # all -- an empty array, a non-finite total, or nothing but zeros.
+        if votes.size == 0 or not np.isfinite(total) or total <= 0.0:
             return None
         return votes / total
 

--- a/src/capymoa/ocl/__init__.py
+++ b/src/capymoa/ocl/__init__.py
@@ -28,17 +28,17 @@ The final accuracy is the accuracy on all tasks after finishing training on all
 tasks:
 
 >>> print(f"Final Accuracy: {metrics.accuracy_final:0.2f}")
-Final Accuracy: 0.59
+Final Accuracy: 0.69
 
 The accuracy on each task after training on each task:
 
 >>> with np.printoptions(precision=2):
 ...     print(metrics.accuracy_matrix)
-[[0.88 0.17 0.08 0.05 0.08]
- [0.85 0.85 0.03 0.05 0.08]
- [0.75 0.77 0.6  0.08 0.03]
- [0.75 0.77 0.52 0.38 0.1 ]
- [0.75 0.75 0.52 0.38 0.57]]
+[[0.9  0.05 0.05 0.05 0.08]
+ [0.88 0.9  0.   0.   0.05]
+ [0.77 0.82 0.62 0.   0.03]
+ [0.77 0.82 0.6  0.52 0.03]
+ [0.77 0.85 0.57 0.52 0.75]]
 
 Notice that the accuracies in the upper triangle are close to zero because the
 learner has not trained on those tasks yet. The diagonal contains the accuracy
@@ -46,10 +46,10 @@ on each task after training on that task. The lower triangle contains the
 accuracy on each task after training on all tasks.
 
 >>> print(f"Forward Transfer: {metrics.forward_transfer:0.2f}")
-Forward Transfer: 0.07
+Forward Transfer: 0.03
 
 >>> print(f"Backward Transfer: {metrics.backward_transfer:0.2f}")
-Backward Transfer: -0.08
+Backward Transfer: -0.07
 """
 
 from . import base, datasets, evaluation, util, strategy

--- a/tests/ocl/test_strategy.py
+++ b/tests/ocl/test_strategy.py
@@ -84,8 +84,13 @@ Use the `partial` function to create a new function with hyperparameters already
 set.
 """
 TEST_CASES: List[Case] = [
-    Case("HoeffdingTree", HoeffdingTree, Result(59.49, 42.59, 45.8), batch_size=1),
-    Case("HoeffdingTree", HoeffdingTree, Result(59.00, 42.80, 42.5), batch_size=32),
+    # These improved when `MOAClassifier.predict_proba` stopped discarding
+    # predictions whose unnormalised vote total was below 1e-2. HoeffdingTree
+    # uses Naive Bayes at its leaves, whose likelihood products fall below that
+    # threshold, so most of its predictions were being thrown away and scored
+    # as misses.
+    Case("HoeffdingTree", HoeffdingTree, Result(69.50, 45.50, 56.3), batch_size=1),
+    Case("HoeffdingTree", HoeffdingTree, Result(69.50, 45.70, 51.0), batch_size=32),
     Case("RAR", _new_rar, Result(44.50, 28.20, 8.20)),
     Case(
         "Finetune",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,3 +1,4 @@
+from capymoa.base import MOAClassifier
 from contextlib import nullcontext
 from itertools import product
 from capymoa.classifier import NoChange
@@ -7,7 +8,12 @@ from capymoa.evaluation.evaluation import (
     PrequentialResults,
 )
 from capymoa.regressor import KNNRegressor
-from capymoa.stream.generator import SEA, HyperPlaneRegression, RandomTreeGenerator
+from capymoa.stream.generator import (
+    SEA,
+    HyperPlaneRegression,
+    RandomTreeGenerator,
+    STAGGERGenerator,
+)
 from capymoa.classifier import NaiveBayes, HoeffdingTree
 from capymoa.evaluation import (
     prequential_evaluation,
@@ -359,3 +365,67 @@ def test_store_y_and_store_predictions(
             )  # NoChange predicts previous y
     else:
         assert pred_y is None, "predictions should not be stored"
+
+
+@pytest.mark.parametrize(
+    "make_stream",
+    [
+        lambda: SEA(function=1),
+        RandomTreeGenerator,
+        STAGGERGenerator,
+        lambda: ElectricityTiny(),
+    ],
+)
+def test_optimise_flag_does_not_change_results(make_stream):
+    """``optimise`` selects a loop, so it must not change the answer.
+
+    `MOAClassifier.predict_proba` used to discard any prediction whose
+    unnormalised vote total was below 1e-2. MOA's votes are not probabilities
+    and their scale depends on the learner, so for Naive Bayes -- products of
+    likelihoods -- that discarded nearly everything. The Python loop scored
+    each discarded prediction as a miss while the Java loop scored it
+    normally, so the two disagreed by up to 52 accuracy points.
+    """
+    accuracies = []
+    for optimise in (True, False):
+        stream = make_stream()
+        results = prequential_evaluation(
+            stream=stream,
+            learner=NaiveBayes(schema=stream.get_schema()),
+            max_instances=2000,
+            optimise=optimise,
+        )
+        accuracies.append(results["cumulative"].accuracy())
+
+    assert accuracies[0] == pytest.approx(accuracies[1], abs=0.01)
+
+
+@pytest.mark.parametrize(
+    ["votes", "expected"],
+    [
+        ([], None),  # no prediction available
+        ([0.0, 0.0], None),  # nothing but zeros
+        ([float("nan"), 1.0], None),
+        ([float("inf"), 1.0], None),
+        ([1e-30, 3e-30], [0.25, 0.75]),  # tiny but perfectly valid
+        ([2.0, 6.0], [0.25, 0.75]),
+    ],
+)
+def test_predict_proba_only_rejects_absent_predictions(votes, expected):
+    """Small vote totals are valid; only absent or degenerate ones are not."""
+
+    class _FakeMOALearner:
+        def getVotesForInstance(self, _):
+            return votes
+
+    class _FakeInstance:
+        java_instance = None
+
+    classifier = MOAClassifier.__new__(MOAClassifier)
+    classifier.moa_learner = _FakeMOALearner()
+
+    result = MOAClassifier.predict_proba(classifier, _FakeInstance())
+    if expected is None:
+        assert result is None
+    else:
+        assert result == pytest.approx(expected)


### PR DESCRIPTION
`MOAClassifier.predict_proba` returned `None` whenever the sum of `getVotesForInstance` was `<= 1e-2`. MOA's votes are unnormalised and their scale depends on the learner — majority-class leaves give integer counts, Naive Bayes gives products of likelihoods that sit far below that threshold without being any less valid.

On SEA, Naive Bayes had a median vote total of `6.29e-04`, so **100% of its predictions were discarded** even though the argmax of those same votes was 87.56% correct. HoeffdingTree is affected through the Naive Bayes at its leaves — 80.2% discarded with the default leaf prediction, 0% with `MajorityClass`.

Everything downstream saw `None` and treated it as "no prediction". In prequential evaluation that scored as a miss, so `optimise=True` and `optimise=False` disagreed by up to **52 accuracy points** on the same stream and learner.

The guard now rejects only votes that carry no prediction: an empty array, a non-finite total, or nothing but zeros. The degenerate cases it was added for are still rejected; small positive totals normalise as they should.

## Consequences

Accuracy for affected learners **improves**, because predictions that were being thrown away are now counted. Pinned expectations updated accordingly — HoeffdingTree on TinySplitMNIST goes from 59.49 to 69.50 final accuracy, in `tests/ocl/test_strategy.py` and the `capymoa.ocl` doctest.

Anyone who published numbers from the non-optimised loop with Naive Bayes or Hoeffding Tree was under-reporting.

## Verification

Both loops now agree exactly on every stream tested:

| stream | before (fast / slow) | after |
|---|---|---|
| SEA | 87.92 / 35.91 | 87.92 / 87.92 |
| RandomTreeGenerator | 73.17 / 41.72 | 73.17 / 73.17 |
| AgrawalGenerator | 87.79 / 67.64 | 87.79 / 87.79 |
| LEDGenerator | 73.43 / 9.59 | 73.43 / 73.43 |
| STAGGER, Sine, ElectricityTiny | already agreed | unchanged |

New tests cover both the agreement and the guard's edge cases (`[]`, all-zeros, NaN, inf still rejected; `[1e-30, 3e-30]` normalises).

## Not included

Notebook outputs are left alone. Two of them display a slightly different accuracy now (`feature_importance` 81.22% → 81.73%, `05_new_learner` 82.52 → 82.77), but regenerating them rewrites ~680 lines of wall-clock timings, temp paths and re-rendered images for those two numbers. Worth a separate refresh if wanted.
