### PR TITLE
test: fix flaky RSHash anomaly detector expectation

### DIFF
--- a/tests/test_anomaly_detectors.py
+++ b/tests/test_anomaly_detectors.py
@@ -105,7 +105,10 @@ from capymoa.stream._stream import Schema
         ),
         (
             partial(RSHash, m=300, s=256, w=4, p=10000, seed=42),
-            0.61,
+            # Measured at 0.61999 in isolation, drifting to ~0.62006 depending
+            # on what ran earlier in the session. 0.61 put the top of the
+            # tolerance at exactly 0.62, so the test failed intermittently.
+            0.62,
             None,
         ),
     ],


### PR DESCRIPTION
The expected AUC was `0.61` with `abs=0.01`, putting the top of the accepted range at exactly `0.62`. RSHash produces `0.61999` in isolation and drifts to ~`0.62006` depending on what ran earlier in the session, so the test failed roughly one run in three — on any PR, whether or not it touched anomaly code. It failed #374 for this reason.

Moving the expectation to `0.62` puts the observed range inside the window rather than on its edge.

Verified with three consecutive full-suite runs: 208 passed each time.

Worth noting separately: the detector is deterministic on its own — seeded with 42 it returns `0.6199850324436417` every run. The drift only appears inside a full pytest session, which points at state left by earlier tests rather than randomness in RSHash. This change stops the false failures; that question is tracked privately.