### PR TITLE
fix(regressor): route SGBR through regression wrapper

### DIFF
--- a/src/capymoa/regressor/_sgbr.py
+++ b/src/capymoa/regressor/_sgbr.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from capymoa.base import (
-    MOAClassifier,
+    MOARegressor,
 )
 from capymoa.stream import Schema
 from capymoa._utils import build_cli_str_from_mapping_and_locals
@@ -9,7 +9,7 @@ from capymoa._utils import build_cli_str_from_mapping_and_locals
 from moa.classifiers.meta import StreamingGradientBoostedRegression as _MOA_SGBR
 
 
-class StreamingGradientBoostedRegression(MOAClassifier):
+class StreamingGradientBoostedRegression(MOARegressor):
     """Streaming Gradient Boosted Regression.
 
     Streaming Gradient Boosted Regression (SGBR) [#0]_, was developed to adapt gradient boosting for streaming regression
@@ -77,7 +77,7 @@ class StreamingGradientBoostedRegression(MOAClassifier):
 
         config_str = build_cli_str_from_mapping_and_locals(mapping, locals())
         super(StreamingGradientBoostedRegression, self).__init__(
-            moa_learner=_MOA_SGBR,
+            moa_learner=_MOA_SGBR(),
             schema=schema,
             CLI=config_str,
             random_seed=random_seed,

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -2,7 +2,7 @@ from contextlib import nullcontext
 import os
 from typing import Optional
 from capymoa.evaluation import RegressionEvaluator, RegressionWindowedEvaluator
-from capymoa.datasets import Fried
+from capymoa.datasets import Fried, FriedTiny
 from capymoa.misc import load_model, save_model
 from capymoa.regressor import (
     KNNRegressor,
@@ -15,13 +15,14 @@ from capymoa.regressor import (
     PassiveAggressiveRegressor,
     SGDRegressor,
     ShrubsRegressor,
+    StreamingGradientBoostedRegression,
     NoChange,
     TargetMean,
     FadingTargetMean,
 )
 from jpype import JException
 import pytest
-from capymoa.base import Regressor
+from capymoa.base import MOAClassifier, MOARegressor, Regressor
 from capymoa.stream import Schema, Stream
 from tempfile import TemporaryDirectory
 from dataclasses import dataclass
@@ -62,6 +63,7 @@ CASES = [
     Case(PassiveAggressiveRegressor, 3.70, 3.68),
     Case(SGDRegressor, 4.63, 3.61),
     Case(ShrubsRegressor, 5.21, 4.76),
+    Case(StreamingGradientBoostedRegression, 3.09, 2.21),
 ]
 """Add your new test cases here ^^"""
 
@@ -93,6 +95,29 @@ def test_regressor(case: Case):
 
     # Test that the model can be saved and loaded.
     subtest_save_and_load(learner, stream, True)
+
+
+def test_streaming_gradient_boosted_regression_predicts_numeric_targets():
+    stream = FriedTiny()
+    learner = StreamingGradientBoostedRegression(schema=stream.get_schema())
+
+    assert isinstance(learner, MOARegressor)
+    assert not isinstance(learner, MOAClassifier)
+
+    predictions = []
+    for _ in range(20):
+        instance = stream.next_instance()
+        predictions.append(learner.predict(instance))
+        learner.train(instance)
+
+    numeric_predictions = [
+        float(prediction) for prediction in predictions if prediction is not None
+    ]
+    rounded_predictions = {round(prediction, 6) for prediction in numeric_predictions}
+
+    assert numeric_predictions
+    assert any(prediction != 0.0 for prediction in numeric_predictions)
+    assert len(rounded_predictions) > 1
 
 
 def test_none_predict():


### PR DESCRIPTION
## Summary

- Route `StreamingGradientBoostedRegression` through `MOARegressor` instead of `MOAClassifier`.
- Instantiate the MOA SGBR learner before passing it to the wrapper, matching the other MOA regressors.
- Add regression coverage for SGBR, including a focused check that Python `predict()` returns numeric, non-constant target predictions.

## Context

The existing doctest-style evaluation could pass before this change because `prequential_evaluation()` defaults to `optimise=True`, which uses MOA's fast Java evaluation loop and bypasses Python `learner.predict()`. The wrapper bug showed up when using the Python path directly, for example manual `predict()` calls or `prequential_evaluation(..., optimise=False)`, where the classifier wrapper reduced predictions to class-index zeros.

## Validation

- `pytest tests/test_regressors.py -k "StreamingGradientBoostedRegression or sgbr" --tb=short`
- `pytest tests/test_regressors.py::test_streaming_gradient_boosted_regression_predicts_numeric_targets --tb=short`
- `pytest --doctest-modules src/capymoa/regressor/_sgbr.py --tb=short`
- `pytest tests/test_regressors.py --tb=short`
- `ruff check src/capymoa/regressor/_sgbr.py tests/test_regressors.py`
- `ruff format --check src/capymoa/regressor/_sgbr.py tests/test_regressors.py`
