### PR TITLE
feat(drift): remove the alpha parameter from Drift and GradualDrift

### DIFF
--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -192,12 +192,15 @@ class Drift:
     .. [1] Bifet, Albert, et al. "Data stream mining: a practical approach." COSI (2011).
     """
 
-    def __init__(self, position, width=0, random_seed=1):
+    def __init__(self, position, width=0, *, random_seed=1):
         """Construct a drift in a DriftStream.
 
         :param position: The location of the drift in terms of the number of instances processed prior to it occurring.
         :param width: The size of the window of change. A width of 0 or 1 corresponds to an abrupt drift.
         :param random_seed: Seed for random number generation, defaults to 1.
+            Keyword-only, so a leftover positional argument from the removed
+            ``alpha`` parameter fails at the call site rather than silently
+            becoming the seed.
         """
         self.width = width
         self.position = position
@@ -242,7 +245,9 @@ class GradualDrift(Drift):
     ValueError: GradualDrift needs exactly one of ``position`` and ``width``, or ``start`` and ``end``, to locate the drift. Got position=100, start=95.
     """
 
-    def __init__(self, position=None, width=None, start=None, end=None, random_seed=1):
+    def __init__(
+        self, position=None, width=None, start=None, end=None, *, random_seed=1
+    ):
         self.__init_args_kwargs__ = copy.copy(
             locals()
         )  # save init args for recreation. not a deep copy to avoid unnecessary use of memory

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -63,7 +63,7 @@ class DriftStream(MOAStream):
 
                         CLI += (
                             f" -d {cli_str_stream(stream2.moa_stream)} -w {drift.width} -p "
-                            f"{drift.position} -r {drift.random_seed} -a {drift.alpha}"
+                            f"{drift.position} -r {drift.random_seed}"
                         )
                         CLI = CLI.replace(
                             "streams.", ""
@@ -192,17 +192,15 @@ class Drift:
     .. [1] Bifet, Albert, et al. "Data stream mining: a practical approach." COSI (2011).
     """
 
-    def __init__(self, position, width=0, alpha=0.0, random_seed=1):
+    def __init__(self, position, width=0, random_seed=1):
         """Construct a drift in a DriftStream.
 
         :param position: The location of the drift in terms of the number of instances processed prior to it occurring.
         :param width: The size of the window of change. A width of 0 or 1 corresponds to an abrupt drift.
-        :param alpha: The grade of change, defaults to 0.0.
         :param random_seed: Seed for random number generation, defaults to 1.
         """
         self.width = width
         self.position = position
-        self.alpha = alpha
         self.random_seed = random_seed
 
     def __str__(self):
@@ -212,7 +210,6 @@ class Drift:
         attributes = [
             f"position={self.position}",
             f"width={self.width}" if self.width not in [0, 1] else None,
-            f"alpha={self.alpha}" if self.alpha != 0.0 else None,
             f"random_seed={self.random_seed}" if self.random_seed != 1 else None,
         ]
         non_default_attributes = [attr for attr in attributes if attr is not None]
@@ -245,9 +242,7 @@ class GradualDrift(Drift):
     ValueError: GradualDrift needs exactly one of ``position`` and ``width``, or ``start`` and ``end``, to locate the drift. Got position=100, start=95.
     """
 
-    def __init__(
-        self, position=None, width=None, start=None, end=None, alpha=0.0, random_seed=1
-    ):
+    def __init__(self, position=None, width=None, start=None, end=None, random_seed=1):
         self.__init_args_kwargs__ = copy.copy(
             locals()
         )  # save init args for recreation. not a deep copy to avoid unnecessary use of memory
@@ -295,7 +290,6 @@ class GradualDrift(Drift):
             self.width = end - start
             self.position = int((start + end) / 2)
 
-        self.alpha = alpha
         self.random_seed = random_seed
 
         super().__init__(
@@ -308,7 +302,6 @@ class GradualDrift(Drift):
             f"start={self.start}",
             f"end={self.end}",
             f"width={self.width}",
-            f"alpha={self.alpha}" if self.alpha != 0.0 else None,
             f"random_seed={self.random_seed}" if self.random_seed != 1 else None,
         ]
         non_default_attributes = [attr for attr in attributes if attr is not None]

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -210,6 +210,38 @@ def test_drift_stream_rejects_python_native_concept():
         )
 
 
+@pytest.mark.parametrize(
+    "call",
+    [
+        # The keyword form callers actually used.
+        lambda: Drift(position=1000, width=500, alpha=0.1),
+        lambda: GradualDrift(position=1000, width=500, alpha=0.1),
+        # The positional forms, where the leftover argument would otherwise
+        # slide into random_seed and only fail later inside MOA with
+        # `NumberFormatException: For input string: "0.1"`.
+        lambda: Drift(1000, 500, 0.1),
+        lambda: GradualDrift(1000, 500, None, None, 0.1),
+    ],
+)
+def test_drift_rejects_leftover_alpha_argument(call):
+    """A leftover ``alpha`` must fail at the call site, keyword or positional.
+
+    ``random_seed`` is keyword-only so that the extra positional argument
+    cannot quietly become the seed.
+    """
+    with pytest.raises(TypeError):
+        call()
+
+
+def test_drift_random_seed_is_keyword_only():
+    """The supported forms still work."""
+    assert Drift(1000, 500).random_seed == 1
+    assert Drift(position=1000, width=500, random_seed=7).random_seed == 7
+    assert GradualDrift(1000, 500).random_seed == 1
+    assert GradualDrift(start=750, end=1250, random_seed=7).random_seed == 7
+    assert AbruptDrift(100).random_seed == 1
+
+
 @pytest.mark.parametrize("cls", [Drift, GradualDrift])
 def test_drift_no_longer_accepts_alpha(cls):
     """``alpha`` was removed: it never shaped the transition.

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -210,6 +210,38 @@ def test_drift_stream_rejects_python_native_concept():
         )
 
 
+@pytest.mark.parametrize("cls", [Drift, GradualDrift])
+def test_drift_no_longer_accepts_alpha(cls):
+    """``alpha`` was removed: it never shaped the transition.
+
+    MOA reads it once in ``prepareForUseImpl``, where a non-zero value
+    *overwrites* ``width`` with ``1/tan(alpha)``. It was a second, obscure
+    spelling of ``width`` rather than a grade of change, and ``GradualDrift``
+    discarded it anyway.
+    """
+    kwargs = {"position": 100, "width": 10, "alpha": 0.1}
+    with pytest.raises(TypeError, match="alpha"):
+        cls(**kwargs)
+
+
+def test_drift_stream_cli_has_no_alpha_option():
+    """The generated MOA CLI no longer carries ``-a``, so width is honoured."""
+    stream = DriftStream(
+        stream=[
+            RandomTreeGenerator(tree_random_seed=1),
+            Drift(position=1000, width=500),
+            RandomTreeGenerator(tree_random_seed=2),
+        ]
+    )
+
+    assert "-a " not in stream._CLI
+    assert "-w 500 -p 1000" in stream._CLI
+
+    moa_stream = stream.moa_stream
+    moa_stream.prepareForUse()
+    assert moa_stream.widthOption.getValue() == 500
+
+
 @pytest.mark.parametrize(
     ["definition", "match"],
     [


### PR DESCRIPTION
`alpha` never shaped the transition. Disassembling the bundled `moa.jar`, `ConceptDriftStream.nextInstance()` computes only `1 / (1 + exp(-4 (n - position) / width))` — `alphaOption` does not appear in it. It is read once, in `prepareForUseImpl`, where a non-zero value **overwrites `width`** with `1/tan(alpha)`:

```
alpha=0.0: requested width=500 -> MOA effective width = 500
alpha=0.1: requested width=500 -> MOA effective width = 572
```

So it was a second, obscure spelling of `width`, not the "grade of change" our docstring described. `GradualDrift` discarded it anyway — it assigned `self.alpha` and then let `Drift.__init__` reset it to `0.0` — so the same parameter behaved differently on two classes in the same module.

Removed rather than repaired: it is a MOA artefact we inherit only because MOA does the mixing.

## Behaviour

The generated CLI no longer emits `-a`, so MOA keeps its own default of `0.0` and the requested width is honoured. That is already what happened for every caller who left `alpha` alone — which is all of them, here and in the notebooks.

Passing it now raises `TypeError` instead of silently changing the drift width. Anyone who was setting it was not getting what they asked for.

`random_seed` is keyword-only on both classes so that the *positional* form fails too. Without that, `Drift(1000, 500, 0.1)` bound `0.1` to `random_seed` and only failed later inside MOA with `NumberFormatException: For input string: "0.1"`. Nothing passes the seed positionally — the only positional use anywhere is the first argument, and recurrent streams rebuild drifts with `drift_cls(**drift_args)`. `AbruptDrift` is unchanged, since it never had `alpha`.

## Verification

211 tests, 126 doctests, 18 notebooks, ruff clean, docs build exits 0 with no warnings. New tests cover the removal and assert the CLI omits `-a` while MOA reports the requested width.
