### PR TITLE
feat(drift): report how many instances each concept contributed

### DIFF
--- a/notebooks/04_drift_streams.ipynb
+++ b/notebooks/04_drift_streams.ipynb
@@ -44,10 +44,10 @@
      "start_time": "2024-07-26T13:56:08.491220Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:00.982827Z",
-     "iopub.status.busy": "2026-08-05T21:23:00.982707Z",
-     "iopub.status.idle": "2026-08-05T21:23:03.280444Z",
-     "shell.execute_reply": "2026-08-05T21:23:03.280089Z"
+     "iopub.execute_input": "2026-08-05T21:38:00.605426Z",
+     "iopub.status.busy": "2026-08-05T21:38:00.605364Z",
+     "iopub.status.idle": "2026-08-05T21:38:02.460466Z",
+     "shell.execute_reply": "2026-08-05T21:38:02.460060Z"
     }
    },
    "outputs": [
@@ -153,10 +153,10 @@
      "start_time": "2024-07-26T13:56:18.756789Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:03.281716Z",
-     "iopub.status.busy": "2026-08-05T21:23:03.281601Z",
-     "iopub.status.idle": "2026-08-05T21:23:03.580786Z",
-     "shell.execute_reply": "2026-08-05T21:23:03.580273Z"
+     "iopub.execute_input": "2026-08-05T21:38:02.462018Z",
+     "iopub.status.busy": "2026-08-05T21:38:02.461881Z",
+     "iopub.status.idle": "2026-08-05T21:38:02.740557Z",
+     "shell.execute_reply": "2026-08-05T21:38:02.740217Z"
     }
    },
    "outputs": [
@@ -226,10 +226,10 @@
      "start_time": "2024-07-26T13:56:19.573531Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:03.582309Z",
-     "iopub.status.busy": "2026-08-05T21:23:03.582197Z",
-     "iopub.status.idle": "2026-08-05T21:23:04.063391Z",
-     "shell.execute_reply": "2026-08-05T21:23:04.062863Z"
+     "iopub.execute_input": "2026-08-05T21:38:02.741849Z",
+     "iopub.status.busy": "2026-08-05T21:38:02.741773Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.196469Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.196017Z"
     }
    },
    "outputs": [
@@ -313,10 +313,10 @@
      "start_time": "2024-07-26T13:56:20.303537Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:04.064440Z",
-     "iopub.status.busy": "2026-08-05T21:23:04.064359Z",
-     "iopub.status.idle": "2026-08-05T21:23:04.205610Z",
-     "shell.execute_reply": "2026-08-05T21:23:04.205221Z"
+     "iopub.execute_input": "2026-08-05T21:38:03.197570Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.197486Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.328657Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.327810Z"
     }
    },
    "outputs": [
@@ -386,10 +386,10 @@
    "id": "range-form-example",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:04.206709Z",
-     "iopub.status.busy": "2026-08-05T21:23:04.206646Z",
-     "iopub.status.idle": "2026-08-05T21:23:04.209634Z",
-     "shell.execute_reply": "2026-08-05T21:23:04.209050Z"
+     "iopub.execute_input": "2026-08-05T21:38:03.329751Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.329658Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.332319Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.331982Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "range-provenance-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:04.210709Z",
-     "iopub.status.busy": "2026-08-05T21:23:04.210642Z",
-     "iopub.status.idle": "2026-08-05T21:23:04.213060Z",
-     "shell.execute_reply": "2026-08-05T21:23:04.212728Z"
+     "iopub.execute_input": "2026-08-05T21:38:03.333312Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.333252Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.335570Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.335199Z"
     }
    },
    "outputs": [
@@ -497,6 +497,53 @@
   },
   {
    "cell_type": "markdown",
+   "id": "concept-counts-md",
+   "metadata": {},
+   "source": [
+    "#### Telling exactly how many instances came from each concept\n",
+    "\n",
+    "* Because the split around a gradual drift depends on the transition, the definition alone does not tell you how much of each concept you actually got.\n",
+    "* ```get_concept_counts(n)``` answers that exactly, and ```describe(n)``` prints it as a table.\n",
+    "* Neither needs the stream to be run first: a transition decides using only its own seeded generator and counter -- the instances never enter the decision -- so the routing is replayed without generating any data. Roughly 0.3s for a million instances.\n",
+    "* This is the number worth quoting in a paper: the drift positions describe the design, these counts describe what the stream actually produced.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "concept-counts-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-05T21:38:03.336724Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.336583Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.339425Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.339119Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DriftStream over 2500 instances, range form\n",
+      "\n",
+      "  concept                             declared    drawn    share\n",
+      "  SEA(function=1)                         1000      999   40.0%\n",
+      "  SEA(function=2)                          500      734   29.4%\n",
+      "  SEA(function=3)                          500      767   30.7%\n",
+      "\n",
+      "  drifts\n",
+      "    AbruptDrift(position=1000)\n",
+      "    GradualDrift(position=1750, start=1500, end=2000, width=500)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(stream_range.describe(2500))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "92cc4281407f615d",
    "metadata": {},
    "source": [
@@ -507,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "db84b34f98ed17dd",
    "metadata": {
     "ExecuteTime": {
@@ -515,10 +562,10 @@
      "start_time": "2024-07-26T13:56:21.017757Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:04.214024Z",
-     "iopub.status.busy": "2026-08-05T21:23:04.213971Z",
-     "iopub.status.idle": "2026-08-05T21:23:04.687233Z",
-     "shell.execute_reply": "2026-08-05T21:23:04.686759Z"
+     "iopub.execute_input": "2026-08-05T21:38:03.340442Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.340374Z",
+     "iopub.status.idle": "2026-08-05T21:38:03.835689Z",
+     "shell.execute_reply": "2026-08-05T21:38:03.835345Z"
     }
    },
    "outputs": [
@@ -595,7 +642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "4b762df18013ff2",
    "metadata": {
     "ExecuteTime": {
@@ -603,10 +650,10 @@
      "start_time": "2024-07-26T13:56:22.320531Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:23:04.688306Z",
-     "iopub.status.busy": "2026-08-05T21:23:04.688219Z",
-     "iopub.status.idle": "2026-08-05T21:23:05.195277Z",
-     "shell.execute_reply": "2026-08-05T21:23:05.194800Z"
+     "iopub.execute_input": "2026-08-05T21:38:03.837559Z",
+     "iopub.status.busy": "2026-08-05T21:38:03.837457Z",
+     "iopub.status.idle": "2026-08-05T21:38:04.368920Z",
+     "shell.execute_reply": "2026-08-05T21:38:04.368571Z"
     }
    },
    "outputs": [

--- a/notebooks/04_drift_streams.ipynb
+++ b/notebooks/04_drift_streams.ipynb
@@ -540,7 +540,7 @@
     }
    ],
    "source": [
-    "print(stream_range.describe())  # horizon defaults to the declared length\n"
+    "print(stream_range.describe())  # horizon defaults to the declared length"
    ]
   },
   {

--- a/notebooks/04_drift_streams.ipynb
+++ b/notebooks/04_drift_streams.ipynb
@@ -44,10 +44,10 @@
      "start_time": "2024-07-26T13:56:08.491220Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:00.605426Z",
-     "iopub.status.busy": "2026-08-05T21:38:00.605364Z",
-     "iopub.status.idle": "2026-08-05T21:38:02.460466Z",
-     "shell.execute_reply": "2026-08-05T21:38:02.460060Z"
+     "iopub.execute_input": "2026-08-05T23:17:44.350414Z",
+     "iopub.status.busy": "2026-08-05T23:17:44.350259Z",
+     "iopub.status.idle": "2026-08-05T23:17:46.750117Z",
+     "shell.execute_reply": "2026-08-05T23:17:46.749482Z"
     }
    },
    "outputs": [
@@ -153,10 +153,10 @@
      "start_time": "2024-07-26T13:56:18.756789Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:02.462018Z",
-     "iopub.status.busy": "2026-08-05T21:38:02.461881Z",
-     "iopub.status.idle": "2026-08-05T21:38:02.740557Z",
-     "shell.execute_reply": "2026-08-05T21:38:02.740217Z"
+     "iopub.execute_input": "2026-08-05T23:17:46.751610Z",
+     "iopub.status.busy": "2026-08-05T23:17:46.751443Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.062993Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.062547Z"
     }
    },
    "outputs": [
@@ -226,10 +226,10 @@
      "start_time": "2024-07-26T13:56:19.573531Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:02.741849Z",
-     "iopub.status.busy": "2026-08-05T21:38:02.741773Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.196469Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.196017Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.064255Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.064164Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.543772Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.543319Z"
     }
    },
    "outputs": [
@@ -313,10 +313,10 @@
      "start_time": "2024-07-26T13:56:20.303537Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.197570Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.197486Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.328657Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.327810Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.544946Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.544865Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.681859Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.681358Z"
     }
    },
    "outputs": [
@@ -386,10 +386,10 @@
    "id": "range-form-example",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.329751Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.329658Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.332319Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.331982Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.683072Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.682975Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.686613Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.686173Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "range-provenance-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.333312Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.333252Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.335570Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.335199Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.687623Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.687564Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.689949Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.689494Z"
     }
    },
    "outputs": [
@@ -514,10 +514,10 @@
    "id": "concept-counts-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.336724Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.336583Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.339425Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.339119Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.690935Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.690864Z",
+     "iopub.status.idle": "2026-08-05T23:17:47.694127Z",
+     "shell.execute_reply": "2026-08-05T23:17:47.693693Z"
     }
    },
    "outputs": [
@@ -526,6 +526,7 @@
      "output_type": "stream",
      "text": [
       "DriftStream over 2500 instances, range form\n",
+      "  horizon: from the declared lengths\n",
       "\n",
       "  concept                             declared    drawn    share\n",
       "  SEA(function=1)                         1000      999   40.0%\n",
@@ -539,7 +540,7 @@
     }
    ],
    "source": [
-    "print(stream_range.describe(2500))"
+    "print(stream_range.describe())  # horizon defaults to the declared length\n"
    ]
   },
   {
@@ -562,10 +563,10 @@
      "start_time": "2024-07-26T13:56:21.017757Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.340442Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.340374Z",
-     "iopub.status.idle": "2026-08-05T21:38:03.835689Z",
-     "shell.execute_reply": "2026-08-05T21:38:03.835345Z"
+     "iopub.execute_input": "2026-08-05T23:17:47.695059Z",
+     "iopub.status.busy": "2026-08-05T23:17:47.695006Z",
+     "iopub.status.idle": "2026-08-05T23:17:48.177604Z",
+     "shell.execute_reply": "2026-08-05T23:17:48.177127Z"
     }
    },
    "outputs": [
@@ -650,10 +651,10 @@
      "start_time": "2024-07-26T13:56:22.320531Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-05T21:38:03.837559Z",
-     "iopub.status.busy": "2026-08-05T21:38:03.837457Z",
-     "iopub.status.idle": "2026-08-05T21:38:04.368920Z",
-     "shell.execute_reply": "2026-08-05T21:38:04.368571Z"
+     "iopub.execute_input": "2026-08-05T23:17:48.178748Z",
+     "iopub.status.busy": "2026-08-05T23:17:48.178671Z",
+     "iopub.status.idle": "2026-08-05T23:17:48.711849Z",
+     "shell.execute_reply": "2026-08-05T23:17:48.711471Z"
     }
    },
    "outputs": [

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -90,7 +90,10 @@ class DriftStream(Stream):
     """A stream composed of concepts separated by drifts.
 
     The stream is defined as a list that alternates concepts and drifts,
-    starting and ending with a concept:
+    starting and ending with a concept. There are **two forms**, and a
+    definition must use one or the other throughout.
+
+    **Positions** -- each drift says where it happens:
 
     >>> from capymoa.stream.drift import DriftStream, AbruptDrift, GradualDrift
     >>> from capymoa.stream.generator import SEA
@@ -103,6 +106,33 @@ class DriftStream(Stream):
     ... ])
     >>> stream.get_num_drifts()
     2
+
+    **Ranges** -- each concept says how long it lasts, and the drifts are
+    placed by what surrounds them. Every concept is wrapped in
+    :class:`Concept`, drifts carry no position, and a :class:`GradualDrift`
+    gives its length instead of a width:
+
+    >>> from capymoa.stream.drift import Concept
+    >>> stream = DriftStream(stream=[
+    ...     Concept(SEA(function=1), num_instances=5000),
+    ...     AbruptDrift(),
+    ...     Concept(SEA(function=3), num_instances=5000),
+    ...     GradualDrift(num_instances=2000),
+    ...     Concept(SEA(function=1), num_instances=1000),
+    ... ])
+    >>> for drift in stream.get_drifts():
+    ...     print(drift)
+    AbruptDrift(position=5000)
+    GradualDrift(position=11000, start=10000, end=12000, width=2000)
+
+    The two cannot be combined. A range definition does not say where its
+    drifts land, so a position supplied alongside it would describe a location
+    the rest of the definition contradicts. Mixing them is rejected rather than
+    resolved by guesswork.
+
+    Use :func:`describe` to see how many instances each concept actually
+    contributed, which around a :class:`GradualDrift` is not what the declared
+    lengths suggest.
 
     Composition happens in Python: instances are drawn from the concept
     selected for the current position, and across a :class:`GradualDrift` the
@@ -321,7 +351,7 @@ class DriftStream(Stream):
             "DriftStream concepts must either all be wrapped in ``Concept`` "
             "(the range form, giving each concept a length) or none of them "
             "(the position form, giving each drift a position). "
-            f"Got {sum(wrapped)} wrapped out of {len(wrapped)} concepts."
+            f"Got {sum(wrapped)} wrapped out of {len(wrapped)} concepts. See ``DriftStream`` for the two forms and how they differ."
         )
 
     @staticmethod
@@ -332,7 +362,7 @@ class DriftStream(Stream):
                 raise ValueError(
                     f"{type(drift).__name__} at drift {i} has no position. "
                     "Give it one, or use the range form by wrapping every "
-                    "concept in ``Concept(stream, num_instances=...)``."
+                    "concept in ``Concept(stream, num_instances=...)``. See ``DriftStream`` for the two forms and how they differ."
                 )
 
     @staticmethod
@@ -360,7 +390,7 @@ class DriftStream(Stream):
                     f"{type(component).__name__} cannot carry a position in a "
                     "range definition -- the concept lengths already determine "
                     "where it lands. Use ``AbruptDrift()`` or "
-                    "``GradualDrift(num_instances=...)``."
+                    "``GradualDrift(num_instances=...)``. See ``DriftStream`` for the two forms and how they differ."
                 )
 
             if isinstance(component, GradualDrift):

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -224,7 +224,32 @@ class DriftStream(Stream):
 
         self._CLI = CLI
 
-    def get_concept_counts(self, num_instances: int):
+    def _default_horizon(self):
+        """How many instances to report on when the caller does not say.
+
+        The range form states its own length, so the total is the sum of what
+        the definition declares. The position form has an open-ended final
+        concept, so its length is estimated from how far apart the drifts are:
+        experiments usually space concepts evenly, and the drift spacing is the
+        only evidence available.
+        """
+        if getattr(self, "range_form", False):
+            declared = sum(c.num_instances for c in self.stream[0::2])
+            declared += sum(d.width for d in self.drifts if isinstance(d, GradualDrift))
+            return declared, False
+
+        positions = [d.position for d in self.drifts]
+        if not positions:
+            raise ValueError(
+                "This DriftStream has no drifts, so there is nothing to "
+                "estimate a horizon from. Pass one explicitly."
+            )
+        gaps = [positions[0]] + [b - a for a, b in zip(positions, positions[1:])]
+        # The final concept is unbounded, so assume it runs about as long as
+        # the others did.
+        return positions[-1] + sum(gaps) // len(gaps), True
+
+    def get_concept_counts(self, horizon: int = None):
         """How many of the first ``num_instances`` come from each concept.
 
         Around an :class:`AbruptDrift` this follows from the definition, but
@@ -250,8 +275,10 @@ class DriftStream(Stream):
         >>> stream.get_concept_counts(2000)
         [1269, 731]
 
-        :param num_instances: How many instances to account for, counted from
-            the start of the stream.
+        :param horizon: How many instances to account for, counted from the
+            start of the stream. Defaults to the length the definition implies
+            -- exact for the range form, estimated for the position form, whose
+            final concept is open-ended.
         :return: One count per concept, in the order they were defined.
             Concepts appearing more than once are counted separately.
         """
@@ -261,10 +288,10 @@ class DriftStream(Stream):
                 "concepts and drifts. This one is backed by a MOA stream, "
                 "which does not expose where each instance came from."
             )
-        if num_instances is None or num_instances < 0:
-            raise ValueError(
-                f"num_instances must be zero or positive, got {num_instances!r}."
-            )
+        if horizon is None:
+            horizon, _ = self._default_horizon()
+        if horizon < 0:
+            raise ValueError(f"horizon must be zero or positive, got {horizon!r}.")
 
         # Fresh state, so this always reports a run from the start of the
         # stream rather than wherever the live stream happens to be.
@@ -283,7 +310,7 @@ class DriftStream(Stream):
 
         prepare(self._root)
 
-        for _ in range(num_instances):
+        for _ in range(horizon):
             node = self._root
             while isinstance(node, _Transition):
                 node._replay_n += 1
@@ -296,18 +323,23 @@ class DriftStream(Stream):
 
         return [counters[id(leaf)] for leaf in leaves]
 
-    def describe(self, num_instances: int) -> str:
+    def describe(self, horizon: int = None) -> str:
         """A readable summary of where the first ``num_instances`` come from.
 
         Intended for reporting a stream in a paper or notebook, where the drift
         positions alone do not say how much of each concept was actually seen.
 
-        :param num_instances: How many instances to account for.
+        :param horizon: How many instances to account for. Defaults to the
+            length the definition implies, which the report labels as exact or
+            estimated.
         :return: A table of concepts, their counts and shares, followed by the
             drifts. When the stream was defined with lengths, the declared
             length is shown alongside for comparison.
         """
-        counts = self.get_concept_counts(num_instances)
+        estimated = False
+        if horizon is None:
+            horizon, estimated = self._default_horizon()
+        counts = self.get_concept_counts(horizon)
         declared = (
             [component.num_instances for component in self.stream[0::2]]
             if getattr(self, "range_form", False)
@@ -315,7 +347,18 @@ class DriftStream(Stream):
         )
 
         form = "range form" if declared else "position form"
-        lines = [f"DriftStream over {num_instances} instances, {form}", ""]
+        how = (
+            "estimated, the final concept is open-ended"
+            if estimated
+            else "from the declared lengths"
+            if declared
+            else "given"
+        )
+        lines = [
+            f"DriftStream over {horizon} instances, {form}",
+            f"  horizon: {how}",
+            "",
+        ]
         header = f"  {'concept':<34}"
         if declared:
             header += f" {'declared':>9}"
@@ -325,7 +368,7 @@ class DriftStream(Stream):
             row = f"  {str(concept)[:34]:<34}"
             if declared:
                 row += f" {declared[i]:>9}"
-            share = count / num_instances if num_instances else 0.0
+            share = count / horizon if horizon else 0.0
             lines.append(row + f" {count:>8} {share:>7.1%}")
 
         lines.append("")

--- a/src/capymoa/stream/drift.py
+++ b/src/capymoa/stream/drift.py
@@ -154,6 +154,7 @@ class DriftStream(Stream):
             for drift, concept in zip(self.drifts, concepts[1:]):
                 root = _Transition(root, _ConceptNode(concept), drift)
             self._root = root
+            self._concepts = list(concepts)
             self._schema = schema or concepts[0].get_schema()
             self._check_concepts_agree(concepts)
         else:
@@ -187,10 +188,121 @@ class DriftStream(Stream):
                         Drift(position=int(matches_position[i]), width=1000)
                     )
 
+            self._concepts = []
             self._moa_backed = MOAStream(schema=schema, CLI=CLI, moa_stream=moa_stream)
             self._schema = self._moa_backed.get_schema()
 
         self._CLI = CLI
+
+    def get_concept_counts(self, num_instances: int):
+        """How many of the first ``num_instances`` come from each concept.
+
+        Around an :class:`AbruptDrift` this follows from the definition, but
+        around a :class:`GradualDrift` the concepts overlap and the split is a
+        property of the transition ramp, which can keep drawing from the older
+        concept past the nominal end of the window. This reports what actually
+        happens.
+
+        The stream does not need to be run. Each transition decides using only
+        its own seeded generator and its own counter -- the instances never
+        enter the decision -- so the routing is replayed with fresh generators
+        and reproduces the same branch pattern without generating any data.
+        That makes it exact rather than an estimate, and fast enough to ask
+        about millions of instances.
+
+        >>> from capymoa.stream.drift import Concept, DriftStream, GradualDrift
+        >>> from capymoa.stream.generator import SEA
+        >>> stream = DriftStream(stream=[
+        ...     Concept(SEA(function=1), num_instances=1000),
+        ...     GradualDrift(num_instances=500),
+        ...     Concept(SEA(function=3), num_instances=500),
+        ... ])
+        >>> stream.get_concept_counts(2000)
+        [1269, 731]
+
+        :param num_instances: How many instances to account for, counted from
+            the start of the stream.
+        :return: One count per concept, in the order they were defined.
+            Concepts appearing more than once are counted separately.
+        """
+        if self._root is None:
+            raise ValueError(
+                "get_concept_counts() needs a DriftStream built from a list of "
+                "concepts and drifts. This one is backed by a MOA stream, "
+                "which does not expose where each instance came from."
+            )
+        if num_instances is None or num_instances < 0:
+            raise ValueError(
+                f"num_instances must be zero or positive, got {num_instances!r}."
+            )
+
+        # Fresh state, so this always reports a run from the start of the
+        # stream rather than wherever the live stream happens to be.
+        counters = {}
+        leaves = []
+
+        def prepare(node):
+            if isinstance(node, _Transition):
+                node._replay_n = 0
+                node._replay_rng = _random.Random(node.drift.random_seed)
+                prepare(node.before)
+                prepare(node.after)
+            else:
+                counters[id(node)] = 0
+                leaves.append(node)
+
+        prepare(self._root)
+
+        for _ in range(num_instances):
+            node = self._root
+            while isinstance(node, _Transition):
+                node._replay_n += 1
+                probability = node.probability_of_new_concept(node._replay_n)
+                if node._replay_rng.random() > probability:
+                    node = node.before
+                else:
+                    node = node.after
+            counters[id(node)] += 1
+
+        return [counters[id(leaf)] for leaf in leaves]
+
+    def describe(self, num_instances: int) -> str:
+        """A readable summary of where the first ``num_instances`` come from.
+
+        Intended for reporting a stream in a paper or notebook, where the drift
+        positions alone do not say how much of each concept was actually seen.
+
+        :param num_instances: How many instances to account for.
+        :return: A table of concepts, their counts and shares, followed by the
+            drifts. When the stream was defined with lengths, the declared
+            length is shown alongside for comparison.
+        """
+        counts = self.get_concept_counts(num_instances)
+        declared = (
+            [component.num_instances for component in self.stream[0::2]]
+            if getattr(self, "range_form", False)
+            else None
+        )
+
+        form = "range form" if declared else "position form"
+        lines = [f"DriftStream over {num_instances} instances, {form}", ""]
+        header = f"  {'concept':<34}"
+        if declared:
+            header += f" {'declared':>9}"
+        lines.append(header + f" {'drawn':>8} {'share':>8}")
+
+        for i, (concept, count) in enumerate(zip(self._concepts, counts)):
+            row = f"  {str(concept)[:34]:<34}"
+            if declared:
+                row += f" {declared[i]:>9}"
+            share = count / num_instances if num_instances else 0.0
+            lines.append(row + f" {count:>8} {share:>7.1%}")
+
+        lines.append("")
+        lines.append("  drifts")
+        for drift in self.drifts:
+            lines.append(f"    {drift}")
+        return "\n".join(lines)
 
     @staticmethod
     def _uses_range_form(components):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -285,6 +285,111 @@ def test_range_form_rejects_contradictory_definitions(definition, match):
         DriftStream(stream=definition())
 
 
+def test_concept_counts_match_actually_consuming_the_stream():
+    """The prediction must be exact, not an estimate.
+
+    Routing depends only on each transition's own seeded generator and
+    counter, never on the instances, so replaying it reproduces the same
+    branch pattern without generating any data.
+    """
+    from capymoa.stream.drift import _ConceptNode
+
+    def build():
+        return DriftStream(
+            stream=[
+                Concept(SEA(function=1), num_instances=1000),
+                AbruptDrift(),
+                Concept(SEA(function=2), num_instances=500),
+                GradualDrift(num_instances=500),
+                Concept(SEA(function=3), num_instances=500),
+            ]
+        )
+
+    predicted = build().get_concept_counts(2500)
+
+    # Count for real, by tagging each leaf of the composition tree.
+    stream = build()
+    leaves = []
+
+    def tag(node):
+        if isinstance(node, _ConceptNode):
+            node.drawn = 0
+            original = node.next_instance
+
+            def counting(_node=node, _original=original):
+                _node.drawn += 1
+                return _original()
+
+            node.next_instance = counting
+            leaves.append(node)
+        else:
+            tag(node.before)
+            tag(node.after)
+
+    tag(stream._root)
+    for _ in range(2500):
+        stream.next_instance()
+
+    assert predicted == [leaf.drawn for leaf in leaves]
+    assert sum(predicted) == 2500
+
+
+def test_concept_counts_show_gradual_overlap():
+    """A gradual drift makes the counts diverge from the declared lengths."""
+    stream = DriftStream(
+        stream=[
+            Concept(SEA(function=1), num_instances=1000),
+            AbruptDrift(),
+            Concept(SEA(function=2), num_instances=500),
+            GradualDrift(num_instances=500),
+            Concept(SEA(function=3), num_instances=500),
+        ]
+    )
+    counts = stream.get_concept_counts(2500)
+
+    # The abrupt drift is a clean switch, so the first concept is exact.
+    assert counts[0] == 999
+    # The two concepts either side of the gradual drift share its window, so
+    # both are drawn from more often than their declared length.
+    assert counts[1] > 500
+    assert counts[2] > 500
+
+
+def test_concept_counts_work_for_the_position_form():
+    stream = DriftStream(
+        stream=[
+            SEA(function=1),
+            AbruptDrift(position=1000),
+            SEA(function=3),
+        ]
+    )
+    assert stream.get_concept_counts(2000) == [999, 1001]
+    assert "position form" in stream.describe(2000)
+
+
+def test_concept_counts_reject_bad_input():
+    stream = DriftStream(
+        stream=[SEA(function=1), AbruptDrift(position=100), SEA(function=3)]
+    )
+    with pytest.raises(ValueError, match="zero or positive"):
+        stream.get_concept_counts(-1)
+
+
+def test_describe_reports_declared_lengths_for_the_range_form():
+    stream = DriftStream(
+        stream=[
+            Concept(SEA(function=1), num_instances=1000),
+            AbruptDrift(),
+            Concept(SEA(function=3), num_instances=500),
+        ]
+    )
+    report = stream.describe(1500)
+
+    assert "range form" in report
+    assert "declared" in report
+    assert "AbruptDrift(position=1000)" in report
+
+
 def test_concept_requires_a_positive_length():
     for bad in (0, -1, None):
         with pytest.raises(ValueError, match="positive ``num_instances``"):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -375,6 +375,44 @@ def test_concept_counts_reject_bad_input():
         stream.get_concept_counts(-1)
 
 
+def test_horizon_defaults_to_the_declared_length_for_the_range_form():
+    stream = DriftStream(
+        stream=[
+            Concept(SEA(function=1), num_instances=1000),
+            GradualDrift(num_instances=200),
+            Concept(SEA(function=3), num_instances=1000),
+        ]
+    )
+    # 1000 + 200 (the drift spends its own) + 1000
+    assert sum(stream.get_concept_counts()) == 2200
+    assert "from the declared lengths" in stream.describe()
+
+
+def test_horizon_is_estimated_for_the_position_form():
+    """The final concept is open-ended, so its length is inferred."""
+    stream = DriftStream(
+        stream=[
+            SEA(function=1),
+            AbruptDrift(position=1000),
+            SEA(function=2),
+            AbruptDrift(position=2000),
+            SEA(function=3),
+        ]
+    )
+    # drifts 1000 apart, so the last concept is assumed to run about as long
+    assert sum(stream.get_concept_counts()) == 3000
+    report = stream.describe()
+    assert "estimated" in report
+    assert "open-ended" in report
+
+
+def test_horizon_must_be_given_when_there_are_no_drifts():
+    stream = DriftStream(stream=[SEA(function=1)])
+    with pytest.raises(ValueError, match="no drifts"):
+        stream.get_concept_counts()
+    assert sum(stream.get_concept_counts(500)) == 500
+
+
 def test_describe_reports_declared_lengths_for_the_range_form():
     stream = DriftStream(
         stream=[


### PR DESCRIPTION
Closes #107 (private backlog).

A `DriftStream` says where its drifts are, but not how much of each concept it actually produced. Around an `AbruptDrift` that follows from the definition; around a `GradualDrift` the concepts overlap and the split depends on the transition.

```python
>>> stream.get_concept_counts(2500)
[999, 738, 763]

>>> print(stream.describe())
DriftStream over 2500 instances, range form
  horizon: from the declared lengths

  concept                       declared    drawn    share
  SEA(function=1)                   1000      999   40.0%
  SEA(function=2)                    500      738   29.5%
  SEA(function=3)                    500      763   30.5%

  drifts
    AbruptDrift(position=1000)
    GradualDrift(position=1750, start=1500, end=2000, width=500)
```

Those counts are what belongs in a paper: the drift positions describe the design, these describe what the stream produced.

## It does not require running the stream

A transition decides using only its own seeded generator and its own counter — the instances never enter the decision — so the routing is replayed with fresh generators and reproduces the same branch pattern without generating any data. Verified against actually consuming the stream, and cheap enough to be predictive:

| | time |
|---|---|
| simulate routing, 1M instances | 0.30s |
| actually generating 50k instances | 0.13s (for comparison) |

So you can state the split over the length you intend to use, before running anything.

## The horizon

Both methods take an optional `horizon`. The range form knows its own answer — the declared lengths add up. The position form does not, because its final concept is open-ended, so it is estimated from how far apart the drifts are. `describe()` says which it used, so an estimate is never mistaken for a measurement:

```
DriftStream over 3000 instances, position form
  horizon: estimated, the final concept is open-ended
```

A stream with no drifts has nothing to infer from and asks for the horizon explicitly.

## Also

The `DriftStream` docstring now documents both definition forms side by side, and the errors raised when they are mixed point at it — the same `Drift` classes serve both forms, so reaching for the wrong one is easy.

## Verification

241 tests, 129 doctests, ruff clean, docs build exits 0 with no warnings. The key test asserts the prediction equals actually consuming the stream, by tagging every leaf of the composition tree.
