### PR TITLE
fix(stream): store generator parameters so __str__ works

### DIFF
--- a/src/capymoa/stream/generator.py
+++ b/src/capymoa/stream/generator.py
@@ -434,6 +434,12 @@ class RandomRBFGenerator(MOAStream):
         :param number_of_drifting_centroids: The number of drifting attributes, defaults to 2
         """
 
+        self.model_random_seed = model_random_seed
+        self.instance_random_seed = instance_random_seed
+        self.number_of_classes = number_of_classes
+        self.number_of_attributes = number_of_attributes
+        self.number_of_centroids = number_of_centroids
+
         mapping = {
             "model_random_seed": "-r",
             "instance_random_seed": "-i",
@@ -503,6 +509,14 @@ class RandomRBFGeneratorDrift(MOAStream):
         :param noise_percentage: Percentage of noise to add to the data, defaults to 10
         :param sigma_percentage: Percentage of sigma to add to the data, defaults to 10
         """
+
+        self.model_random_seed = model_random_seed
+        self.instance_random_seed = instance_random_seed
+        self.number_of_classes = number_of_classes
+        self.number_of_attributes = number_of_attributes
+        self.number_of_centroids = number_of_centroids
+        self.number_of_drifting_centroids = number_of_drifting_centroids
+        self.magnitude_of_change = magnitude_of_change
 
         mapping = {
             "model_random_seed": "-r",
@@ -796,6 +810,9 @@ class WaveformGenerator(MOAStream):
         :param noise: Adds noise for a total of 40 attributes
         """
 
+        self.instance_random_seed = instance_random_seed
+        self.noise = noise
+
         mapping = {
             "instance_random_seed": "-i",
             "noise": "-n",
@@ -852,6 +869,10 @@ class WaveformGeneratorDrift(MOAStream):
         :param noise: Adds noise for a total of 40 attributes
         :param number_of_attributes_with_drift: Number of attributes with drift
         """
+
+        self.instance_random_seed = instance_random_seed
+        self.noise = noise
+        self.number_of_attributes_with_drift = number_of_attributes_with_drift
 
         mapping = {
             "instance_random_seed": "-i",
@@ -911,6 +932,10 @@ class STAGGERGenerator(MOAStream):
         :param classification_function: Classification function used, as defined in the original paper.
         :param balance: Balance the number of instances of each class.
         """
+
+        self.instance_random_seed = instance_random_seed
+        self.classification_function = classification_function
+        self.balance_classes = balance_classes
 
         mapping = {
             "instance_random_seed": "-i",
@@ -976,6 +1001,11 @@ class SineGenerator(MOAStream):
         :param suppress_irrelevant_attributes: Reduce the data to only contain 2 relevant numeric attributes
         :param balance: Balance the number of instances of each class.
         """
+
+        self.instance_random_seed = instance_random_seed
+        self.classification_function = classification_function
+        self.suppress_irrelevant_attributes = suppress_irrelevant_attributes
+        self.balance_classes = balance_classes
 
         mapping = {
             "instance_random_seed": "-i",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,5 +1,6 @@
 """This module is for testing the speeds of different stream implementations."""
 
+import inspect
 from functools import partial
 from typing import Optional
 
@@ -30,7 +31,13 @@ from capymoa.stream.drift import (
     GradualDrift,
     RecurrentConceptDriftStream,
 )
-from capymoa.stream.generator import SEA, LEDGeneratorDrift, RandomTreeGenerator
+from capymoa.stream import generator
+from capymoa.stream.generator import (
+    SEA,
+    LEDGeneratorDrift,
+    RandomRBFGenerator,
+    RandomTreeGenerator,
+)
 from pathlib import Path
 
 allclose = partial(np.allclose, atol=0.001, equal_nan=True)
@@ -126,6 +133,58 @@ def test_led_generator_drift_str_with_drift_attributes():
     stream = LEDGeneratorDrift(number_of_attributes_with_drift=1)
 
     assert str(stream) == "LEDGeneratorDrift(number_of_attributes_with_drift=1)"
+
+
+def _public_generators():
+    """Every generator class defined in :mod:`capymoa.stream.generator`.
+
+    Discovered rather than listed so that a newly added generator is covered
+    without anyone remembering to extend this test.
+    """
+    return [
+        member
+        for member in vars(generator).values()
+        if inspect.isclass(member)
+        and member.__module__ == generator.__name__
+        and not member.__name__.startswith("_")
+    ]
+
+
+@pytest.mark.parametrize(
+    "generator_class", _public_generators(), ids=lambda cls: cls.__name__
+)
+def test_generator_can_be_printed(generator_class):
+    """Printing a generator must not raise.
+
+    The generators that build their MOA CLI from ``locals()`` never assigned
+    their arguments to ``self``, so ``__str__`` read attributes that did not
+    exist and ``print(stream)`` raised ``AttributeError``.
+    """
+    assert str(generator_class())
+
+
+def test_drift_stream_describes_a_random_rbf_concept():
+    """A concept that cannot be printed takes the whole report down with it.
+
+    ``DriftStream.__str__`` and :meth:`DriftStream.describe` both print their
+    concepts, so an unprintable generator made them fail for the stream as a
+    whole rather than only for that one concept.
+    """
+    stream = DriftStream(
+        stream=[
+            RandomRBFGenerator(model_random_seed=1),
+            Drift(position=2000),
+            RandomRBFGenerator(model_random_seed=99),
+        ]
+    )
+
+    assert str(stream) == (
+        "RandomRBFGenerator(),AbruptDrift(position=2000),"
+        "RandomRBFGenerator(model_random_seed=99)"
+    )
+    report = stream.describe()
+    assert "RandomRBFGenerator" in report
+    assert "AbruptDrift(position=2000)" in report
 
 
 def test_recurrent_concept_drift_stream_accepts_gradual_position_width():


### PR DESCRIPTION
Six generators in `capymoa.stream.generator` build their MOA CLI string from `locals()` and never assign the constructor arguments to `self`, so `__str__` reads attributes that were never set: `RandomRBFGenerator`, `RandomRBFGeneratorDrift`, `STAGGERGenerator`, `SineGenerator`, `WaveformGenerator` and `WaveformGeneratorDrift`. `print(stream)` on any of them raises `AttributeError`, and since `DriftStream.__str__` and `DriftStream.describe()` print their concepts, both fail for any drift stream built from one of the six:

```python
DriftStream(stream=[RandomRBFGenerator(model_random_seed=1), Drift(position=2000),
                    RandomRBFGenerator(model_random_seed=99)]).describe()
```

This assigns the arguments, as the other eight generators in the module already do, and adds a parameterized test that calls `str()` on every public generator class in the module — discovered by inspection, so a new generator is covered without anyone remembering — plus one for `DriftStream.describe()` over a `RandomRBFGenerator` concept.

Verified locally: `pytest tests/` 270 passed / 25 skipped, doctests 129 passed, `ruff format --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
