### PR TITLE
fix(drift): make ABCD usable without PyTorch, and default to PCA

### DIFF
--- a/docs/setup/index.rst
+++ b/docs/setup/index.rst
@@ -112,9 +112,13 @@ evaluation -- installs without pulling a deep-learning stack.
 The parts of CapyMOA that use deep learning do require it:
 :mod:`capymoa.ocl`, :mod:`capymoa.ann`, :class:`capymoa.stream.TorchStream`,
 the ``Batch*`` learners, :class:`capymoa.anomaly.Autoencoder`,
-:class:`capymoa.classifier.Finetune`, :class:`capymoa.ssl.OSNN` and the ABCD
-drift detector. Using one of those without PyTorch raises an
-``OptionalDependencyError`` telling you what to install.
+:class:`capymoa.classifier.Finetune` and :class:`capymoa.ssl.OSNN`. Using one of
+those without PyTorch raises an ``OptionalDependencyError`` telling you what to
+install.
+
+:class:`capymoa.drift.detectors.ABCD` is a partial case: it works without
+PyTorch on its default ``model_id="pca"`` and on ``"kpca"``, and needs the extra
+only for the autoencoder model, ``model_id="ae"``.
 
 Install CapyMOA with PyTorch using the ``torch`` extra:
 

--- a/src/capymoa/drift/detectors/__init__.py
+++ b/src/capymoa/drift/detectors/__init__.py
@@ -1,4 +1,4 @@
-from capymoa._optional import lazy_torch_attrs
+from .abcd import ABCD
 from .adwin import ADWIN
 from .cusum import CUSUM
 from .ddm import DDM
@@ -29,14 +29,3 @@ __all__ = [
     "STEPD",
     "STUDD",
 ]
-
-
-#: ABCD uses a torch autoencoder. Imported on first access so ``import capymoa``
-#: stays torch-free -- see :mod:`capymoa._optional`.
-_LAZY = {
-    "ABCD": ".abcd",
-}
-
-__getattr__, __dir__ = lazy_torch_attrs(
-    __name__, _LAZY, "the ABCD drift detector", __all__
-)

--- a/src/capymoa/drift/detectors/abcd.py
+++ b/src/capymoa/drift/detectors/abcd.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 import numpy as np
 
 from .abcd_components.feature_extraction import (
-    AutoEncoder,
     EncoderDecoder,
     PCAModel,
     KernelPCAModel,
@@ -20,7 +19,7 @@ class ABCD(BaseDriftDetector):
         self,
         delta_drift: float = 0.002,
         delta_warn: float = 0.01,
-        model_id: str = "ae",
+        model_id: str = "pca",
         split_type: str = "ed",
         encoding_factor: float = 0.5,
         update_epochs: int = 50,
@@ -34,7 +33,10 @@ class ABCD(BaseDriftDetector):
         """
         :param delta_drift: The desired confidence level at which a drift is detected
         :param delta_warn: The desired confidence level at which a warning is detected
-        :param model_id: The name of the model to use
+        :param model_id: Which encoder-decoder to reconstruct instances with:
+            ``"pca"``, ``"kpca"`` or ``"ae"``. ``"pca"`` is the default because
+            it needs only scikit-learn, whereas ``"ae"`` is backed by PyTorch,
+            which CapyMOA installs only as the ``torch`` extra.
         :param update_epochs: The number of epochs to train the AE after a change occurred
         :param split_type: Investigation of different split types
         :param subspace_threshold: Called tau in the paper
@@ -78,9 +80,23 @@ class ABCD(BaseDriftDetector):
         elif model_id == "kpca":
             self.model_class = KernelPCAModel
         elif model_id == "ae":
+            # Imported here rather than at module level so that the two
+            # scikit-learn models stay usable without the ``torch`` extra.
+            from capymoa._optional import torch_available
+
+            if not torch_available():
+                from capymoa.exception import OptionalDependencyError
+
+                raise OptionalDependencyError(
+                    "PyTorch", "ABCD's autoencoder model (model_id='ae')"
+                )
+            from .abcd_components._autoencoder import AutoEncoder
+
             self.model_class = AutoEncoder
         else:
-            raise ValueError
+            raise ValueError(
+                f"Unknown model_id {model_id!r}, expected 'pca', 'kpca' or 'ae'"
+            )
         super(ABCD, self).__init__()
 
     def get_params(self) -> Dict[str, Any]:

--- a/src/capymoa/drift/detectors/abcd_components/_autoencoder.py
+++ b/src/capymoa/drift/detectors/abcd_components/_autoencoder.py
@@ -1,0 +1,70 @@
+"""The PyTorch-backed encoder-decoder for :class:`~capymoa.drift.detectors.ABCD`.
+
+Kept apart from :mod:`.feature_extraction` so that importing ABCD does not import
+PyTorch. ``AutoEncoder`` subclasses :class:`torch.nn.Module`, so the import cannot
+be deferred into a method -- the class statement itself needs it -- which is why
+this lives in its own module and is loaded only when ``model_id="ae"``.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim
+
+from .feature_extraction import EncoderDecoder
+
+
+class AutoEncoder(nn.Module, EncoderDecoder):
+    def __init__(self, input_size: int, eta: float):
+        """
+        A simple single layer autoencoder
+        :param input_size: The size of the input
+        :param eta: The encoding factor. Hidden layer size is eta * input_size
+        """
+        super(AutoEncoder, self).__init__()
+        self.eta = eta
+        self.input_size = input_size
+        self.bottleneck_size = int(eta * input_size)
+        self.encoder = nn.Linear(
+            in_features=self.input_size, out_features=self.bottleneck_size
+        )
+        self.decoder = nn.Linear(
+            in_features=self.bottleneck_size, out_features=self.input_size
+        )
+        self.optimizer = torch.optim.Adam(self.parameters())
+
+    def forward(self, x):
+        x = torch.relu(self.encoder(x))
+        x = torch.sigmoid(self.decoder(x))
+        return x
+
+    def update(self, window, epochs: int = 1):
+        """
+        Update the autoencoder on the given window
+        :param window: The data
+        :param epochs: The number of training epochs
+        :param logger: If a logger is provided, log the reconstruction loss during training
+        :return:
+        """
+        if len(window) == 0:
+            return
+        self.train()
+        tensor = torch.from_numpy(window).float()
+        for ep in range(epochs):
+            self.optimizer.zero_grad()
+            pred = self.forward(tensor)
+            loss = F.mse_loss(pred, tensor)
+            loss.backward()
+            self.optimizer.step()
+
+    def new_tuple(self, x):
+        """
+        :param x: Input instance
+        :return: A new tuple containing, MSE, reconstruction, and original
+        """
+        tensor = torch.from_numpy(x).float()
+        self.eval()
+        with torch.no_grad():
+            pred = self.forward(tensor)
+            loss = F.mse_loss(pred, tensor)
+            return loss.item(), pred.numpy()[0], x[0]

--- a/src/capymoa/drift/detectors/abcd_components/feature_extraction.py
+++ b/src/capymoa/drift/detectors/abcd_components/feature_extraction.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import Protocol, Any, Tuple
 
 import numpy as np
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.optim
 from sklearn.decomposition import PCA, KernelPCA
 
 
@@ -31,62 +28,6 @@ class DummyEncoderDecoder(EncoderDecoder):
 
     def new_tuple(self, x) -> Tuple[Any, Any, Any]:
         return 0.0, x, x
-
-
-class AutoEncoder(nn.Module, EncoderDecoder):
-    def __init__(self, input_size: int, eta: float):
-        """
-        A simple single layer autoencoder
-        :param input_size: The size of the input
-        :param eta: The encoding factor. Hidden layer size is eta * input_size
-        """
-        super(AutoEncoder, self).__init__()
-        self.eta = eta
-        self.input_size = input_size
-        self.bottleneck_size = int(eta * input_size)
-        self.encoder = nn.Linear(
-            in_features=self.input_size, out_features=self.bottleneck_size
-        )
-        self.decoder = nn.Linear(
-            in_features=self.bottleneck_size, out_features=self.input_size
-        )
-        self.optimizer = torch.optim.Adam(self.parameters())
-
-    def forward(self, x):
-        x = torch.relu(self.encoder(x))
-        x = torch.sigmoid(self.decoder(x))
-        return x
-
-    def update(self, window, epochs: int = 1):
-        """
-        Update the autoencoder on the given window
-        :param window: The data
-        :param epochs: The number of training epochs
-        :param logger: If a logger is provided, log the reconstruction loss during training
-        :return:
-        """
-        if len(window) == 0:
-            return
-        self.train()
-        tensor = torch.from_numpy(window).float()
-        for ep in range(epochs):
-            self.optimizer.zero_grad()
-            pred = self.forward(tensor)
-            loss = F.mse_loss(pred, tensor)
-            loss.backward()
-            self.optimizer.step()
-
-    def new_tuple(self, x):
-        """
-        :param x: Input instance
-        :return: A new tuple containing, MSE, reconstruction, and original
-        """
-        tensor = torch.from_numpy(x).float()
-        self.eval()
-        with torch.no_grad():
-            pred = self.forward(tensor)
-            loss = F.mse_loss(pred, tensor)
-            return loss.item(), pred.numpy()[0], x[0]
 
 
 class PCAModel(EncoderDecoder):

--- a/tests/test_no_torch.py
+++ b/tests/test_no_torch.py
@@ -185,3 +185,79 @@ def test_all_keeps_lazy_names_when_torch_present():
     for name in ("Batch", "BatchClassifier", "BatchRegressor"):
         assert name in base.__all__, name
     assert "Finetune" in classifier.__all__
+
+
+def test_abcd_runs_without_torch_on_its_scikit_learn_models():
+    """ABCD's ``pca``/``kpca`` models reconstruct with scikit-learn, not PyTorch.
+
+    The autoencoder lives in its own module for exactly this reason, so these
+    two configurations have to stay usable in a default install.
+    """
+    result = _run_without_torch("""
+        import numpy as np
+        from capymoa.drift.detectors import ABCD
+
+        rng = np.random.default_rng(0)
+        data = np.vstack([rng.uniform(0, 0.5, (300, 2)), rng.uniform(0.5, 1.0, (300, 2))])
+
+        for model_id in ("pca", "kpca"):
+            detector = ABCD(model_id=model_id)
+            for row in data:
+                detector.add_element(row)
+
+        # The default must be one of them, or a plain ABCD() breaks the default install.
+        ABCD()
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_abcd_autoencoder_reports_the_model_not_the_detector():
+    """``model_id="ae"`` is the only ABCD configuration needing the extra.
+
+    The error names the model rather than ABCD as a whole, so it does not imply
+    the detector is unavailable when only one of its three models is.
+    """
+    result = _run_without_torch("""
+        from capymoa.drift.detectors import ABCD
+        from capymoa.exception import OptionalDependencyError
+
+        try:
+            ABCD(model_id="ae")
+        except OptionalDependencyError as error:
+            assert "model_id='ae'" in str(error), str(error)
+            print("OK")
+        else:
+            raise AssertionError("expected OptionalDependencyError")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_abcd_stays_in_all_without_torch():
+    """ABCD is importable in a torch-free install, so it must stay advertised."""
+    result = _run_without_torch("""
+        import capymoa.drift.detectors as detectors
+
+        assert "ABCD" in detectors.__all__
+        assert detectors.ABCD is not None
+        print("OK")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_abcd_autoencoder_still_works_when_torch_present():
+    """The move to a separate module must not change behaviour with torch installed."""
+    pytest.importorskip("torch")
+    import numpy as np
+    from capymoa.drift.detectors import ABCD
+
+    rng = np.random.default_rng(0)
+    data = np.vstack([rng.uniform(0, 0.5, (200, 2)), rng.uniform(0.5, 1.0, (200, 2))])
+
+    detector = ABCD(model_id="ae")
+    for row in data:
+        detector.add_element(row)
+    assert detector.idx == len(data)


### PR DESCRIPTION
ABCD reconstructs instances with one of three encoder-decoder models, but only the autoencoder needs PyTorch. `PCAModel` and `KernelPCAModel` use scikit-learn, which is a core dependency. All three shared a module whose top-level `import torch.nn` put the whole detector behind the torch gate, so a default install lost CapyMOA's only multivariate drift detector even for configurations that never touch PyTorch.

`AutoEncoder` moves to its own module. It subclasses `nn.Module`, so the import cannot be deferred into a method; a separate file is what lets `abcd.py` load it lazily and only when `model_id="ae"` is requested. Asking for that model without the extra raises an error naming the model rather than the detector:

```
OptionalDependencyError: PyTorch is required for ABCD's autoencoder model (model_id='ae').
Install it with: pip install capymoa[torch]
```

**The default changes from `"ae"` to `"pca"`**, so a plain `ABCD()` works in a default install. That alters which model an existing caller gets and belongs in the release notes. On the univariate stream in the drift detection notebook the two behave identically (1 detection, 2 warnings, first at 1011), so its stored output is unchanged.

Verified in a real torch-free virtualenv, not only with the `sys.meta_path` simulation: ABCD imports, stays in `__all__`, and `pca`/`kpca`/default all run with torch never entering `sys.modules`.

Closes the follow-up left open by #370, which supplies `capymoa._optional` and `OptionalDependencyError`.
