### PR TITLE
ci: raise the notebook timeout so slower runners have room

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -233,7 +233,14 @@ def notebooks(
     # Set the environment variable to run the notebooks in fast mode.
     if not slow:
         environ["NB_FAST"] = "true"
-        timeout = 60 * 3
+        # Ten minutes, not three. The Windows runners are several times slower than
+        # Linux, and `anomaly_detection.ipynb` crossed the old cap there during the
+        # 0.14.0 release while passing comfortably on Linux and macOS. Skipping the
+        # notebook was the alternative, and `invoke.yml` rightly argues against that:
+        # a skipped notebook stops telling us when it breaks. The underlying cost is
+        # a defect in OnlineIsolationForest rather than a notebook that is genuinely
+        # this expensive; once that is fixed this can come back down.
+        timeout = 60 * 10
     else:
         timeout = -1
 


### PR DESCRIPTION
The 0.14.0 release failed on `windows-latest`: `anomaly_detection.ipynb` exceeded the three-minute nbmake cap. It runs in about 30 seconds locally and passes on Linux and macOS, so it was close enough to the cap that a slower runner crossed it.

Raises the timeout to ten minutes. The alternative was putting the notebook back in `test_skip_notebooks`, which `invoke.yml` argues against — a skipped notebook stops reporting when it breaks, and this one was un-skipped deliberately in 2024.

This buys room rather than fixing the cause. Roughly 25 of the notebook's 31 seconds are a single `OnlineIsolationForest` cell, which constructs a `ThreadPoolExecutor` twice per instance while defaulting to one worker. That is tracked separately and should let the timeout come back down.