### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 /src/capymoa/cluster/   @cassales
 /src/capymoa/drift/     @vcerqueira
 /src/capymoa/feature/   @hmgomes
-/src/capymoa/ocl/       @tachyonicClock
+/src/capymoa/ocl/       @tachyonicClock @nuwangunasekara
 /src/capymoa/interval/  @YibinSun
-/src/capymoa/regressor/ @YibinSun
+/src/capymoa/regressor/ @YibinSun @nuwangunasekara
 /src/capymoa/ssl/       @tachyonicClock

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS
+#
+# Each line maps a domain of src/capymoa to its maintainer.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/src/capymoa/anomaly/            @justinuliu
+/src/capymoa/automl/             @hmgomes
+/src/capymoa/classifier/         @hmgomes
+/src/capymoa/clusterers/         @cassales
+/src/capymoa/drift/              @vcerqueira
+/src/capymoa/feature_selection/  @hmgomes
+/src/capymoa/ocl/                @tachyonicClock
+/src/capymoa/prediction_interval/ @YibinSun
+/src/capymoa/regressor/          @YibinSun
+/src/capymoa/ssl/                @tachyonicClock

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,13 +3,13 @@
 # Each line maps a domain of src/capymoa to its maintainer.
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/src/capymoa/anomaly/            @justinuliu
-/src/capymoa/automl/             @hmgomes
-/src/capymoa/classifier/         @hmgomes
-/src/capymoa/clusterers/         @cassales
-/src/capymoa/drift/              @vcerqueira
-/src/capymoa/feature_selection/  @hmgomes
-/src/capymoa/ocl/                @tachyonicClock
-/src/capymoa/prediction_interval/ @YibinSun
-/src/capymoa/regressor/          @YibinSun
-/src/capymoa/ssl/                @tachyonicClock
+/src/capymoa/anomaly/   @justinuliu
+/src/capymoa/automl/    @hmgomes
+/src/capymoa/classifier/ @hmgomes
+/src/capymoa/cluster/   @cassales
+/src/capymoa/drift/     @vcerqueira
+/src/capymoa/feature/   @hmgomes
+/src/capymoa/ocl/       @tachyonicClock
+/src/capymoa/interval/  @YibinSun
+/src/capymoa/regressor/ @YibinSun
+/src/capymoa/ssl/       @tachyonicClock

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,6 @@
 /src/capymoa/drift/     @vcerqueira
 /src/capymoa/feature/   @hmgomes
 /src/capymoa/ocl/       @tachyonicClock @nuwangunasekara
-/src/capymoa/interval/  @YibinSun
+/src/capymoa/uncertainty/  @YibinSun
 /src/capymoa/regressor/ @YibinSun @nuwangunasekara
 /src/capymoa/ssl/       @tachyonicClock


### PR DESCRIPTION
## Summary
- Add a `CODEOWNERS` file mapping each `src/capymoa` research domain to its maintainer (anomaly, automl, classifier, cluster, drift, feature, ocl, interval, regressor, ssl)
- Paths reflect the current directory layout after the research-domains reorg (`clusterers` -> `cluster`, `feature_selection` -> `feature`, `prediction_interval` -> `interval`)

## Test plan
- [ ] Confirm GitHub recognizes the file and shows correct owners on a sample PR touching each path

Closes adaptive-machine-learning/backlog#146
