### PR TITLE
docs(AGENTS.md): add agent attribution instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,22 @@
 * Run notebook tests with `uv run pytest -q --nbmake notebooks`.
 * Build documentation with `uv run invoke docs`.
 * Clean documentation with `uv run invoke docs.clean`.
+* MUST run formatter `uv run invoke fmt` before committing code.
+* MUST ask the user before pushing to GitHub.
+
+## Commit messages
+
 * SHOULD use conventional commit messages. You MAY introduce breaking changes, but MUST
   NOT include `!` or `BREAKING CHANGE` in the commit message since we are pre v1.0.0.
-* MUST run formatter `uv run invoke fmt` before committing code.
 * MUST NOT add `Co-Authored-By: Claude <noreply@anthropic.com>` (or similar) to commit messages.
-* MUST ask the user before pushing to GitHub.
+* MUST add `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2] ...` to commit messages.
+    * `AGENT_NAME` is the name of the harness (/tool/framework)
+    * `MODEL_VERSION` is the specific model version. SHOULD be as specific as possible
+       including model family, version, and size.
+    * `[TOOL1] [TOOL2]` are optional agent developer tools or MCP. SHOULD NOT include
+       basic developer tools.
+    * Example: `Assisted-by: claude-code:claude-sonnet-4.6 github-mcp-server`
+    * Example: `Assisted-by: copilot:gemini-3.7-flash`
 
 ## Documentation
 
@@ -23,3 +34,4 @@
 * If it is possible to cut a word out, you SHOULD cut it out.
 * SHOULD avoid complex sentence structures. 
 * Consider using commas or parenthesis over em-dash or removing the clause entirely.
+


### PR DESCRIPTION
Follows the [linux, *Process Documentation AI Coding Assistants*](https://github.com/torvalds/linux/blob/3aa1dcaa4f6f5ae08936491e08bd456f331f2d40/Documentation/process/coding-assistants.rst#attribution) instructions for agent attribution.

See also: https://github.com/microsoft/vscode/issues/313962


