### PR TITLE
feat(datasets): add Airlines, KDD99, Nomao, Spambase, PokerHand and a generic OpenML loader

### DIFF
--- a/src/capymoa/datasets/__init__.py
+++ b/src/capymoa/datasets/__init__.py
@@ -11,6 +11,7 @@ array([0.      , 0.056443, 0.439155, 0.003467, 0.422915, 0.414912])
 """
 
 from ._datasets import (
+    Airlines,
     Bike,
     CovtFD,
     Covtype,
@@ -21,13 +22,19 @@ from ._datasets import (
     Fried,
     FriedTiny,
     Hyper100k,
+    KDD99,
+    Nomao,
+    PokerHand,
     RBFm_100k,
     RTG_2abrupt,
     Sensor,
+    Spambase,
 )
+from ._openml import load_openml_dataset
 from ._utils import get_download_dir, download_unpacked
 
 __all__ = [
+    "Airlines",
     "Bike",
     "CovtFD",
     "Covtype",
@@ -38,9 +45,14 @@ __all__ = [
     "Fried",
     "FriedTiny",
     "Hyper100k",
+    "KDD99",
+    "Nomao",
+    "PokerHand",
     "RBFm_100k",
     "RTG_2abrupt",
     "Sensor",
+    "Spambase",
     "get_download_dir",
     "download_unpacked",
+    "load_openml_dataset",
 ]

--- a/src/capymoa/datasets/_datasets.py
+++ b/src/capymoa/datasets/_datasets.py
@@ -328,6 +328,9 @@ class Airlines(_DownloadableARFF):
 
     **References:**
 
+    #.  Ikonomovska, Elena. "Airline Data Set." Data Expo Competition (2009):
+        http://kt.ijs.si/elena_ikonomovska/data.html (archived:
+        https://web.archive.org/web/20110718072348/http://kt.ijs.si/elena_ikonomovska/data.html).
     #.  Bifet, Albert, and Elena Ikonomovska. "airlines." OpenML (2014):
         https://www.openml.org/d/1169.
     """
@@ -351,9 +354,10 @@ class KDD99(_DownloadableARFF):
 
     **References:**
 
-    #.  Stolfo, Salvatore J., Wei Fan, Wenke Lee, Andreas Prodromidis, and Philip
-        K. Chan. "KDD cup 1999 data." OpenML (1999):
-        https://www.openml.org/d/1113.
+    #.  Stolfo, Salvatore, Wei Fan, Wenke Lee, Andreas Prodromidis, and Philip
+        Chan. "KDD Cup 1999 Data." UCI Machine Learning Repository (1999):
+        https://doi.org/10.24432/C51C7N.
+    #.  "KDDCup99." OpenML (2014): https://www.openml.org/d/1113.
     """
 
     _target_type = "categorical"
@@ -377,8 +381,9 @@ class Nomao(_DownloadableARFF):
 
     #.  Candillier, Laurent, and Vincent Lemaire. "Design and analysis of the
         Nomao challenge active learning in the real-world." Proceedings of the
-        ALRA: Active Learning in Real-world Applications, Workshop ECML-PKDD.
-        2012: https://www.openml.org/d/1486.
+        ALRA: Active Learning in Real-world Applications, Workshop ECML-PKDD
+        (2012): https://archive.ics.uci.edu/ml/datasets/Nomao.
+    #.  "nomao." OpenML (2015): https://www.openml.org/d/1486.
     """
 
     _target_type = "categorical"
@@ -403,7 +408,9 @@ class Spambase(_DownloadableARFF):
 
     #.  Hopkins, Mark, Erik Reeber, George Forman, and Jaap Suermondt.
         "Spambase." UCI Machine Learning Repository (1999):
-        https://www.openml.org/d/44.
+        https://archive.ics.uci.edu/dataset/94/spambase,
+        https://doi.org/10.24432/C53G6X.
+    #.  "spambase." OpenML (2014): https://www.openml.org/d/44.
     """
 
     _target_type = "categorical"
@@ -427,8 +434,8 @@ class PokerHand(_DownloadableARFF):
 
     #.  Cattral, Robert, Franz Oppacher, and Dwight Deugo. "Evolutionary data
         mining with automatic rule generalization." Recent Advances in
-        Computers, Computing and Communications (2002):
-        https://www.openml.org/d/1567.
+        Computers, Computing and Communications (2002).
+    #.  "poker-hand." OpenML (2015): https://www.openml.org/d/1567.
     """
 
     _target_type = "categorical"

--- a/src/capymoa/datasets/_datasets.py
+++ b/src/capymoa/datasets/_datasets.py
@@ -314,3 +314,122 @@ class Bike(_DownloadableARFF):
 
     _target_type = "numeric"
     _length = 17_379
+
+
+class Airlines(_DownloadableARFF):
+    """Airlines dataset inspired in the regression dataset from Elena Ikonomovska.
+
+    * Number of instances: 539,383
+    * Number of attributes: 8
+    * Number of targets: 2
+
+    The task is to predict whether a given flight will be delayed, given the information
+    of the scheduled departure.
+
+    **References:**
+
+    #.  Bifet, Albert, and Elena Ikonomovska. "airlines." OpenML (2014):
+        https://www.openml.org/d/1169.
+    """
+
+    _target_type = "categorical"
+    _length = 539383
+
+
+class KDD99(_DownloadableARFF):
+    """KDD99 is a network intrusion detection problem based on a 10% stratified
+    subsample of the 1998 DARPA Intrusion Detection Evaluation Program data.
+
+    * Number of instances: 494,020
+    * Number of attributes: 41
+    * Number of classes: 23
+
+    The task is to distinguish between normal connections and different types of
+    network intrusions (attacks), grouped into four main categories: denial-of-service,
+    unauthorized access from a remote machine, unauthorized access to local
+    superuser privileges, and surveillance/probing.
+
+    **References:**
+
+    #.  Stolfo, Salvatore J., Wei Fan, Wenke Lee, Andreas Prodromidis, and Philip
+        K. Chan. "KDD cup 1999 data." OpenML (1999):
+        https://www.openml.org/d/1113.
+    """
+
+    _target_type = "categorical"
+    _length = 494_020
+
+
+class Nomao(_DownloadableARFF):
+    """Nomao is a deduplication classification problem based on data aggregated
+    by the Nomao Labs search engine.
+
+    * Number of instances: 34,465
+    * Number of attributes: 118
+    * Number of classes: 2
+
+    The task is to determine whether two place records (containing information
+    such as names, phone numbers, and addresses collected from several sources)
+    refer to the same real-world place. The attributes measure similarity and
+    matching characteristics across the various fields of the records being compared.
+
+    **References:**
+
+    #.  Candillier, Laurent, and Vincent Lemaire. "Design and analysis of the
+        Nomao challenge active learning in the real-world." Proceedings of the
+        ALRA: Active Learning in Real-world Applications, Workshop ECML-PKDD.
+        2012: https://www.openml.org/d/1486.
+    """
+
+    _target_type = "categorical"
+    _length = 34_465
+
+
+class Spambase(_DownloadableARFF):
+    """Spambase is a classification problem based on the classic UCI Spambase
+    email dataset from Hewlett-Packard Labs.
+
+    * Number of instances: 4,601
+    * Number of attributes: 57
+    * Number of classes: 2
+
+    The task is to predict whether a given email is spam. Spam emails were
+    collected from postmaster and individual submissions, while non-spam
+    emails came from filed work and personal correspondence. Attributes
+    consist of word and character frequency measures as well as measures of
+    the length of consecutive sequences of capital letters.
+
+    **References:**
+
+    #.  Hopkins, Mark, Erik Reeber, George Forman, and Jaap Suermondt.
+        "Spambase." UCI Machine Learning Repository (1999):
+        https://www.openml.org/d/44.
+    """
+
+    _target_type = "categorical"
+    _length = 4_601
+
+
+class PokerHand(_DownloadableARFF):
+    """PokerHand is a classification problem where each instance is an example
+    of a hand consisting of five playing cards drawn from a standard deck of 52.
+
+    * Number of instances: 1,025,009
+    * Number of attributes: 10
+    * Number of classes: 10
+
+    Each card is described using two attributes (suit and rank), for a total
+    of 10 predictive attributes. The task is to predict the poker hand,
+    ranging from nothing to royal flush. Note that the order of cards is
+    important, so there are 480 possible Royal Flush hands instead of just 4.
+
+    **References:**
+
+    #.  Cattral, Robert, Franz Oppacher, and Dwight Deugo. "Evolutionary data
+        mining with automatic rule generalization." Recent Advances in
+        Computers, Computing and Communications (2002):
+        https://www.openml.org/d/1567.
+    """
+
+    _target_type = "categorical"
+    _length = 1_025_009

--- a/src/capymoa/datasets/_openml.py
+++ b/src/capymoa/datasets/_openml.py
@@ -1,0 +1,147 @@
+"""Generic loading of datasets directly from OpenML by their numeric dataset id."""
+
+import json
+from pathlib import Path
+from typing import List, Optional, Union
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+from capymoa.datasets._utils import (
+    download_unpacked,
+    get_download_dir,
+    infer_unpacked_path,
+    is_already_downloaded,
+)
+from capymoa.stream import Stream, stream_from_file
+
+_OPENML_API = "https://www.openml.org/api/v1/json/data/{id}"
+
+
+def _fetch_description(openml_id: int, cache_dir: Path, auto_download: bool) -> dict:
+    """Return the OpenML API JSON description for a dataset id.
+
+    Cached as ``<cache_dir>/description.json`` so repeated loads never re-hit
+    the OpenML API once fetched once.
+    """
+    cache_path = cache_dir / "description.json"
+    if cache_path.exists():
+        return json.loads(cache_path.read_text())
+
+    if not auto_download:
+        raise FileNotFoundError(
+            f"OpenML metadata for dataset {openml_id} not cached in {cache_dir}. "
+            "Set auto_download=True to fetch it."
+        )
+
+    url = _OPENML_API.format(id=openml_id)
+    try:
+        with urlopen(url) as response:
+            payload = json.load(response)
+    except HTTPError as e:
+        message = f"OpenML API returned HTTP {e.code} for dataset {openml_id}."
+        try:
+            body = json.loads(e.read())
+            message = body["error"]["message"]
+        except (json.JSONDecodeError, KeyError, ValueError):
+            pass
+        raise ValueError(
+            f"Could not fetch OpenML dataset {openml_id}: {message}"
+        ) from e
+    except URLError as e:
+        raise ConnectionError(f"Could not reach the OpenML API: {e.reason}") from e
+
+    description = payload["data_set_description"]
+    cache_path.write_text(json.dumps(description))
+    return description
+
+
+def _attribute_names(path: Path) -> List[str]:
+    """Parse ``@attribute <name> <type>`` lines from an ARFF file, up to ``@data``."""
+    names = []
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped.lower().startswith("@data"):
+                break
+            if not stripped.lower().startswith("@attribute"):
+                continue
+            rest = stripped[len("@attribute") :].strip()
+            if rest.startswith("'") or rest.startswith('"'):
+                quote = rest[0]
+                end = rest.find(quote, 1)
+                name = rest[1:end]
+            else:
+                name = rest.split(None, 1)[0]
+            names.append(name)
+    return names
+
+
+def load_openml_dataset(
+    openml_id: int,
+    directory: Optional[Union[str, Path]] = None,
+    auto_download: bool = True,
+) -> Stream:
+    """Load any OpenML dataset by numeric id as a :class:`~capymoa.stream.Stream`.
+
+    Fetches the dataset's metadata from the OpenML API (cached to disk after
+    the first call, so subsequent loads never re-hit OpenML), downloads its
+    ARFF file (cached under ``<download_dir>/openml/<openml_id>/``), resolves
+    the target column declared by OpenML's ``default_target_attribute``, and
+    returns a :class:`~capymoa.stream.Stream`.
+
+    >>> from capymoa.datasets import load_openml_dataset
+    >>> stream = load_openml_dataset(1169)  # doctest: +SKIP
+
+    :param openml_id: The numeric OpenML dataset id, e.g. ``1169`` for
+        https://www.openml.org/d/1169.
+    :param directory: Where downloads are stored. Defaults to
+        :func:`capymoa.datasets.get_download_dir`.
+    :param auto_download: Fetch metadata / download the dataset if missing.
+    :raises ValueError: If the dataset is not stored as ARFF on OpenML, or its
+        target attribute is missing, ambiguous, or not found in the ARFF file.
+    :raises ConnectionError: If the OpenML API cannot be reached.
+    :raises FileNotFoundError: If the metadata or dataset is missing locally
+        and ``auto_download`` is False.
+    """
+    dataset_dir = get_download_dir(directory) / "openml" / str(openml_id)
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+
+    description = _fetch_description(openml_id, dataset_dir, auto_download)
+
+    if description.get("format", "").upper() != "ARFF":
+        raise ValueError(
+            f"OpenML dataset {openml_id} is not available in ARFF format "
+            f"(got {description.get('format')!r})."
+        )
+
+    target = description.get("default_target_attribute")
+    if not target or "," in target:
+        raise ValueError(
+            f"OpenML dataset {openml_id} does not have a single target attribute "
+            f"(default_target_attribute={target!r})."
+        )
+
+    url = description["url"]
+    if not is_already_downloaded(url, dataset_dir):
+        if not auto_download:
+            raise FileNotFoundError(
+                f"OpenML dataset {openml_id} not found in {dataset_dir}. "
+                "Set auto_download=True to download it."
+            )
+        download_unpacked(url, dataset_dir)
+    path = infer_unpacked_path(url, dataset_dir)
+
+    names = _attribute_names(path)
+    try:
+        class_index = names.index(target)
+    except ValueError:
+        raise ValueError(
+            f"Target attribute {target!r} for OpenML dataset {openml_id} was not "
+            f"found among the ARFF attributes in {path}."
+        ) from None
+
+    return stream_from_file(
+        path,
+        dataset_name=description.get("name", f"openml_{openml_id}"),
+        class_index=class_index,
+    )

--- a/src/capymoa/datasets/_openml.py
+++ b/src/capymoa/datasets/_openml.py
@@ -2,9 +2,11 @@
 
 import json
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
+
+from moa.streams import ArffFileStream
 
 from capymoa.datasets._utils import (
     download_unpacked,
@@ -12,17 +14,14 @@ from capymoa.datasets._utils import (
     infer_unpacked_path,
     is_already_downloaded,
 )
-from capymoa.stream import Stream, stream_from_file
+from capymoa.stream import ARFFStream, Stream
 
 _OPENML_API = "https://www.openml.org/api/v1/json/data/{id}"
 
 
 def _fetch_description(openml_id: int, cache_dir: Path, auto_download: bool) -> dict:
-    """Return the OpenML API JSON description for a dataset id.
-
-    Cached as ``<cache_dir>/description.json`` so repeated loads never re-hit
-    the OpenML API once fetched once.
-    """
+    # Cached as `<cache_dir>/description.json` so repeated loads never re-hit
+    # the OpenML API once fetched once.
     cache_path = cache_dir / "description.json"
     if cache_path.exists():
         return json.loads(cache_path.read_text())
@@ -38,14 +37,8 @@ def _fetch_description(openml_id: int, cache_dir: Path, auto_download: bool) -> 
         with urlopen(url) as response:
             payload = json.load(response)
     except HTTPError as e:
-        message = f"OpenML API returned HTTP {e.code} for dataset {openml_id}."
-        try:
-            body = json.loads(e.read())
-            message = body["error"]["message"]
-        except (json.JSONDecodeError, KeyError, ValueError):
-            pass
         raise ValueError(
-            f"Could not fetch OpenML dataset {openml_id}: {message}"
+            f"Could not fetch OpenML dataset {openml_id}: HTTP {e.code} {e.reason}"
         ) from e
     except URLError as e:
         raise ConnectionError(f"Could not reach the OpenML API: {e.reason}") from e
@@ -55,25 +48,16 @@ def _fetch_description(openml_id: int, cache_dir: Path, auto_download: bool) -> 
     return description
 
 
-def _attribute_names(path: Path) -> List[str]:
-    """Parse ``@attribute <name> <type>`` lines from an ARFF file, up to ``@data``."""
-    names = []
-    with open(path, "r", encoding="utf-8", errors="replace") as f:
-        for line in f:
-            stripped = line.strip()
-            if stripped.lower().startswith("@data"):
-                break
-            if not stripped.lower().startswith("@attribute"):
-                continue
-            rest = stripped[len("@attribute") :].strip()
-            if rest.startswith("'") or rest.startswith('"'):
-                quote = rest[0]
-                end = rest.find(quote, 1)
-                name = rest[1:end]
-            else:
-                name = rest.split(None, 1)[0]
-            names.append(name)
-    return names
+def _resolve_class_index(path: Path, target: str) -> int:
+    # Let MOA parse the ARFF header (it has to anyway) rather than hand-rolling
+    # an ARFF parser, and find the 0-based index of the named target attribute.
+    header = ArffFileStream(str(path), -1).getHeader()
+    for i in range(header.numAttributes()):
+        if str(header.attribute(i).name()) == target:
+            return i
+    raise ValueError(
+        f"Target attribute {target!r} was not found among the ARFF attributes in {path}."
+    )
 
 
 def load_openml_dataset(
@@ -83,14 +67,15 @@ def load_openml_dataset(
 ) -> Stream:
     """Load any OpenML dataset by numeric id as a :class:`~capymoa.stream.Stream`.
 
-    Fetches the dataset's metadata from the OpenML API (cached to disk after
-    the first call, so subsequent loads never re-hit OpenML), downloads its
-    ARFF file (cached under ``<download_dir>/openml/<openml_id>/``), resolves
-    the target column declared by OpenML's ``default_target_attribute``, and
-    returns a :class:`~capymoa.stream.Stream`.
-
     >>> from capymoa.datasets import load_openml_dataset
-    >>> stream = load_openml_dataset(1169)  # doctest: +SKIP
+    >>> stream = load_openml_dataset(61)  # iris
+    >>> stream.next_instance()
+    LabeledInstance(
+        Schema(iris),
+        x=[5.1 3.5 1.4 0.2],
+        y_index=0,
+        y_label='Iris-setosa'
+    )
 
     :param openml_id: The numeric OpenML dataset id, e.g. ``1169`` for
         https://www.openml.org/d/1169.
@@ -103,6 +88,9 @@ def load_openml_dataset(
     :raises FileNotFoundError: If the metadata or dataset is missing locally
         and ``auto_download`` is False.
     """
+    # Cache metadata and the ARFF file together, namespaced by id, so repeated
+    # loads for the same dataset never re-download or re-hit the OpenML API,
+    # and different ids never collide on a shared filename.
     dataset_dir = get_download_dir(directory) / "openml" / str(openml_id)
     dataset_dir.mkdir(parents=True, exist_ok=True)
 
@@ -131,17 +119,5 @@ def load_openml_dataset(
         download_unpacked(url, dataset_dir)
     path = infer_unpacked_path(url, dataset_dir)
 
-    names = _attribute_names(path)
-    try:
-        class_index = names.index(target)
-    except ValueError:
-        raise ValueError(
-            f"Target attribute {target!r} for OpenML dataset {openml_id} was not "
-            f"found among the ARFF attributes in {path}."
-        ) from None
-
-    return stream_from_file(
-        path,
-        dataset_name=description.get("name", f"openml_{openml_id}"),
-        class_index=class_index,
-    )
+    class_index = _resolve_class_index(path, target)
+    return ARFFStream(path=path, class_index=class_index)

--- a/src/capymoa/datasets/_source_list.py
+++ b/src/capymoa/datasets/_source_list.py
@@ -68,23 +68,23 @@ SOURCE_LIST: Dict[str, _Source] = {
         "https://www.dropbox.com/scl/fi/srwuiua429eqf4um750z0/bike.csv.gz?rlkey=6e537xxjvs2hcaev73fkpc4yy&st=2gebrfhf&dl=1",
     ),
     "Airlines": _Source(
-        "https://www.openml.org/data/download/66526/phpvcoG8S.arff",
-        None,
+        "https://www.dropbox.com/scl/fi/eqd4umtf2zfnpnxhih6g2/airlines.arff.gz?rlkey=llyu3ykwgwoy8u71y96nspoh4&st=e52abisn&dl=1",
+        "https://www.dropbox.com/scl/fi/yodn679r1isxo8nwwvtqi/airlines.csv.gz?rlkey=cnuukfv2yq9duau97lx753ajl&st=ofu92em1&dl=1",
     ),
     "KDD99": _Source(
-        "https://www.openml.org/data/download/53996/KDDCup99.arff",
-        None,
+        "https://www.dropbox.com/scl/fi/flainlfk15tut2p3qxdgd/KDDCup99.arff.gz?rlkey=gt03mezzps6euezgmhgpqsifv&st=ky0dt0dg&dl=1",
+        "https://www.dropbox.com/scl/fi/om7h280kd8ngpqrbf1pwb/KDDCup99.csv.gz?rlkey=o9v8doagsblac92s4540vfxnu&st=x246j61e&dl=1",
     ),
     "Nomao": _Source(
-        "https://www.openml.org/data/download/1592278/nomao.arff",
-        None,
+        "https://www.dropbox.com/scl/fi/w9mhmi9zs4ie67m4412es/nomao.arff.gz?rlkey=p3gbrolfhell804buxdhvm8wb&st=u4ijyoad&dl=1",
+        "https://www.dropbox.com/scl/fi/jiotnvoamhgybykfzhc2s/nomao.csv.gz?rlkey=tnc7cucfccgycwdrhp3fjqslr&st=rxisj2x3&dl=1",
     ),
     "Spambase": _Source(
-        "https://www.openml.org/data/download/44/spambase.arff",
-        None,
+        "https://www.dropbox.com/scl/fi/cc2gfwpti7vkv6d4vea62/spambase.arff.gz?rlkey=k2w0jzvfkawsljw32ex8s9yxu&st=z8twhqoh&dl=1",
+        "https://www.dropbox.com/scl/fi/et2h3ufed4dhp5enmiais/spambase.csv.gz?rlkey=gicmu7l309g5c7jdazuhlwp5q&st=pbnrrwi7&dl=1",
     ),
     "PokerHand": _Source(
-        "https://www.openml.org/data/download/1675986/poker-hand.arff",
-        None,
+        "https://www.dropbox.com/scl/fi/6od40wxphdsgo20hxyama/poker-hand.arff.gz?rlkey=0pmk5fb8al4aw7r1xfb41hux5&st=ar7ub159&dl=1",
+        "https://www.dropbox.com/scl/fi/zvw65ifq8w1i85wh68qq2/poker-hand.csv.gz?rlkey=j7pamjd4kqeaymzs8x2f32mku&st=nmuxbghi&dl=1",
     ),
 }

--- a/src/capymoa/datasets/_source_list.py
+++ b/src/capymoa/datasets/_source_list.py
@@ -67,4 +67,24 @@ SOURCE_LIST: Dict[str, _Source] = {
         "https://www.dropbox.com/scl/fi/r3lmdpzhyzv2h0mdh4802/bike.arff.gz?rlkey=9eq3x5onmgtpmhi1kpjs25u4c&st=ikx0urzf&dl=1",
         "https://www.dropbox.com/scl/fi/srwuiua429eqf4um750z0/bike.csv.gz?rlkey=6e537xxjvs2hcaev73fkpc4yy&st=2gebrfhf&dl=1",
     ),
+    "Airlines": _Source(
+        "https://www.openml.org/data/download/66526/phpvcoG8S.arff",
+        None,
+    ),
+    "KDD99": _Source(
+        "https://www.openml.org/data/download/53996/KDDCup99.arff",
+        None,
+    ),
+    "Nomao": _Source(
+        "https://www.openml.org/data/download/1592278/nomao.arff",
+        None,
+    ),
+    "Spambase": _Source(
+        "https://www.openml.org/data/download/44/spambase.arff",
+        None,
+    ),
+    "PokerHand": _Source(
+        "https://www.openml.org/data/download/1675986/poker-hand.arff",
+        None,
+    ),
 }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,7 @@
 from typing import Sized, Type
 import capymoa.datasets as capymoa_datasets
 from capymoa.stream import Stream
-from capymoa.datasets import ElectricityTiny
+from capymoa.datasets import ElectricityTiny, load_openml_dataset
 from tempfile import TemporaryDirectory
 import pytest
 import numpy as np
@@ -54,6 +54,26 @@ def test_electricity_tiny_schema():
     for y_index, y_value in enumerate(schema.get_label_values()):
         assert schema.get_index_for_label(y_value) == y_index
         assert schema.get_value_for_index(y_index) == y_value
+
+
+@pytest.mark.skip("Avoid hitting the OpenML API during routine test runs")
+def test_load_openml_dataset_iris():
+    if platform.system() == "Windows":
+        pytest.skip("Skipping on Windows, because TemporaryDirectory fails to cleanup.")
+
+    with TemporaryDirectory() as tmp_dir:
+        with pytest.raises(FileNotFoundError):
+            load_openml_dataset(61, directory=tmp_dir, auto_download=False)
+
+        stream = load_openml_dataset(61, directory=tmp_dir)
+        schema = stream.get_schema()
+        assert schema.get_num_attributes() == 4
+        assert schema.get_num_classes() == 3
+        assert schema.is_classification()
+
+        # Cached path should work without downloading again.
+        stream2 = load_openml_dataset(61, directory=tmp_dir, auto_download=False)
+        assert stream2.get_schema().get_num_attributes() == 4
 
 
 @pytest.mark.skip("This test is too slow")


### PR DESCRIPTION
Adds:
- `capymoa.datasets.load_openml_dataset`
- `KDD99`
- `Airlines`
- `Nomao`
- `PokerHand`
- `Spambase`

I used openml as the host for these ARFF files rather than dropbox.

<img width="643" height="662" alt="image" src="https://github.com/user-attachments/assets/4abfa88b-3ead-4070-8c39-15ccaf83a7ac" />



Assisted-by: claude-code:claude-sonnet-5