### PR TITLE
fix(base): pad predict_proba to the schema's class count

### DIFF
--- a/src/capymoa/base/_classifier.py
+++ b/src/capymoa/base/_classifier.py
@@ -117,6 +117,14 @@ class MOAClassifier(Classifier):
 
     def predict_proba(self, instance) -> Optional[LabelProbabilities]:
         votes = np.array(self.moa_learner.getVotesForInstance(instance.java_instance))
+        # MOA sizes the vote array by the classes seen so far, not by the
+        # schema, so it can be shorter than `schema.get_num_classes()`. Votes
+        # are indexed by class index, so pad with trailing zeros to line the
+        # array up with the schema (padding an empty array still yields all
+        # zeros, so the "no prediction" case below is unaffected).
+        num_classes = self.schema.get_num_classes()
+        if votes.size < num_classes:
+            votes = np.pad(votes, (0, num_classes - votes.size))
         total = votes.sum() if votes.size else 0.0
         # MOA returns unnormalised scores, and their scale depends on the
         # learner: majority-class leaves give integer counts, while Naive Bayes

--- a/src/capymoa/classifier/_dems.py
+++ b/src/capymoa/classifier/_dems.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import Optional
-
-import numpy as np
-
 from capymoa.base import MOAClassifier
 from capymoa.stream import Schema
 from capymoa._utils import build_cli_str_from_mapping_and_locals
-from capymoa.core import LabelProbabilities
 
 from moa.classifiers.meta import DynamicEnsembleMemberSelection as _MOA_DEMS
 
@@ -163,19 +158,3 @@ class DynamicEnsembleMemberSelection(MOAClassifier):
             CLI=config_str,
             random_seed=random_seed,
         )
-
-    def predict_proba(self, instance) -> Optional[LabelProbabilities]:
-        votes = np.array(
-            self.moa_learner.getVotesForInstance(instance.java_instance),
-            dtype=np.float64,
-        )
-
-        if self.schema is not None:
-            num_classes = self.schema.get_num_classes()
-            if votes.shape[0] < num_classes:
-                votes = np.pad(votes, (0, num_classes - votes.shape[0]))
-
-        total = sum(votes)
-        if total <= 1e-2 or np.isnan(total) or np.isinf(total):
-            return None
-        return votes / total

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -43,6 +43,7 @@ from capymoa.evaluation import ClassificationEvaluator, prequential_evaluation
 from capymoa.core.io import load_model, save_model
 from capymoa.core.moa.splitcriteria import GiniSplitCriterion
 from capymoa.stream import Schema, Stream
+from capymoa.stream.generator import RandomTreeGenerator
 import numpy as np
 
 
@@ -370,3 +371,23 @@ def test_classifiers(test_case: ClassifierTestCase, subtests: SubTests):
     if isinstance(learner, MOAClassifier) and test_case.cli_string is not None:
         cli_str = cli_str_classifier(learner).strip("()")
         assert cli_str == test_case.cli_string, "CLI does not match expected value"
+
+    # `predict_proba` must always be shaped by the schema, not by the classes
+    # seen so far (https://github.com/adaptive-machine-learning/backlog/issues/96).
+    with subtests.test(msg="predict_proba_shape"):
+        many_classes_stream = RandomTreeGenerator(num_classes=7)
+        many_classes_learner: Classifier = test_case.learner_constructor(
+            schema=many_classes_stream.get_schema()
+        )
+        for _ in range(5):
+            many_classes_learner.train(next(many_classes_stream))
+        many_classes_proba = many_classes_learner.predict_proba(
+            next(many_classes_stream)
+        )
+        if many_classes_proba is not None:
+            assert many_classes_proba.shape == (7,), (
+                f"Expected shape (7,), got {many_classes_proba.shape}"
+            )
+            assert sum(many_classes_proba) == pytest.approx(1.0, abs=1e-5), (
+                "Probability sum != 1"
+            )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -421,8 +421,13 @@ def test_predict_proba_only_rejects_absent_predictions(votes, expected):
     class _FakeInstance:
         java_instance = None
 
+    class _FakeSchema:
+        def get_num_classes(self):
+            return 2
+
     classifier = MOAClassifier.__new__(MOAClassifier)
     classifier.moa_learner = _FakeMOALearner()
+    classifier.schema = _FakeSchema()
 
     result = MOAClassifier.predict_proba(classifier, _FakeInstance())
     if expected is None:


### PR DESCRIPTION
## Problem

`MOAClassifier.predict_proba` can return an array shorter than `schema.get_num_classes()`.

```python
stream = CovtypeTiny()                      # 7 classes
learner = HoeffdingTree(stream.schema, grace_period=1)
# ...train on 3 instances (labels 4, 4, 1)...
learner.predict_proba(stream.next_instance())
# array([0., 0.33333333, 0., 0., 0.66666667])   <- length 5, want 7
```

MOA's `getVotesForInstance` sizes its return array by the classes seen so far, not by the
schema. Votes are indexed by class index, so the missing entries are always trailing
zeros — this is truncation, not reordering.

Verified against the current `moa.jar`: 19 of 25 classifiers in `capymoa.classifier`
returned a short array after 20 training instances on `CovtypeTiny`. The 6 that looked
correct were the scikit-learn and torch backed learners, which don't go through
`MOAClassifier`. So this is one bug in the shared wrapper, not a per-learner bug.

`predict` is unaffected (argmax over a truncated array still gives the right index), and
the evaluators build their own vote template. Only `predict_proba` callers see it.

Refs adaptive-machine-learning/backlog#96

## Changes

1. **Pad in `MOAClassifier.predict_proba`** — zero-pad `votes` to
   `schema.get_num_classes()` before the total-is-usable check and the normalisation.
   Pads only when short; a longer array is left alone. The existing reject rules (empty,
   non-finite total, total <= 0) are unchanged — padding an empty array still yields all
   zeros, so the "no prediction" case still returns `None`.

2. **Delete the duplicate override in `DynamicEnsembleMemberSelection`** — it hand-rolled
   the same padding, which is why it was one of the 6 that looked correct. It also carried
   the old `total <= 1e-2` reject rule that was deliberately removed from the base class
   (see `test_optimise_flag_does_not_change_results`). Now dead weight.

3. **Fix the existing unit test's fake classifier** — `test_predict_proba_only_rejects_absent_predictions`
   builds via `MOAClassifier.__new__` and set only `moa_learner`, so reading `self.schema`
   would raise. It now gets a fake schema reporting 2 classes, matching its 2-element vote
   cases. No `getattr` guard was added to the implementation to accommodate the test.

4. **Regression test across all classifiers** — the existing shape assertion in
   `test_classifiers` only passed because it uses `ElectricityTiny` (2 classes) after a
   full prequential run, by which point both classes have been seen. Added a subtest using
   a fresh learner on `RandomTreeGenerator(num_classes=7)` (no dataset download) that
   asserts shape `(7,)` and that values sum to 1, skipping when `predict_proba` returns
   `None` since abstaining is allowed. Reuses `test_case.learner_constructor`, so every
   registered classifier is covered.

## Upstream

The underlying bug is in MOA itself: `HoeffdingTree.getVotesForInstance` delegates to the
leaf's `getClassVotes`, which returns `observedClassDistribution.getArrayCopy()` — a
`DoubleVector` trimmed to the highest class index observed. Notably the `treeRoot == null`
branch a few lines below *does* size correctly with `inst.dataset().numClasses()`.

`moa.jar` is a prebuilt binary pulled from the URL in `invoke.yml`, so the Java fix can't
land here. A bug report for `Waikato/moa` has been drafted separately. The CapyMOA padding
is worth keeping either way, since it covers every MOA learner rather than one class.

## Verification

- The issue's snippet now prints a length-7 array summing to 1.
- Swept every classifier in `capymoa.classifier` on `CovtypeTiny` after 20 instances: all
  25 return length 7. Before the fix, 19 returned 5.
- `pytest tests/test_classifiers.py tests/test_evaluation.py tests/test_ssl_classifiers.py` —
  79 passed, 1 skipped, 52 subtests passed.
- `pytest tests` — 290 passed, 25 skipped.
- `pytest --doctest-modules src` — 129 passed.
- `invoke fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)