### PR TITLE
fix: replace deprecated sklearn PassiveAggressive estimators

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   tests:
@@ -30,16 +30,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # For Pull Requests we run tests on Ubuntu with Python 3.10.
+        # For Pull Requests we run tests on Ubuntu with Python 3.11.
         # In releases we will test on more configurations.
         operating-system:
           - ubuntu-latest
           # - windows-latest
           # - macos-latest
         python-version:
-          - '3.10'
-          # - '3.11'
+          - '3.11'
           # - '3.12'
+          # - '3.13'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Python 3.9->3.11 on Ubuntu, Windows and MacOS
+        # Python 3.11->3.13 on Ubuntu, Windows and MacOS
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v3
       - uses: astral-sh/setup-uv@v6

--- a/docs/setup/index.rst
+++ b/docs/setup/index.rst
@@ -10,7 +10,7 @@ Setup
 =====
 
 This document describes how to install CapyMOA and its dependencies. CapyMOA is
-tested against Python 3.10, 3.11, and 3.12. Newer versions of Python will likely
+tested against Python 3.11, 3.12, and 3.13. Newer versions of Python will likely
 work but have yet to be tested.
 
 Once you have installed the :ref:`dependencies`, you may

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 ]
 
 long_description_content_type = "text/markdown"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 # Defines the pip packages that are required by this package. These should be
 # as permissive as possible, since capymoa should collaborate with other
 # packages.
@@ -251,7 +251,7 @@ upload_to_vcs_release = true
 
 # Configuration for the formatter
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "matplotlib~=3.10",
     "numpy~=2.2",
     "pandas~=2.2",
-    "scikit-learn~=1.7",
+    "scikit-learn~=1.8",
     "seaborn~=0.13",
     "tqdm~=4.67",
     # `typing_extensions.override` is used across the core modules. It used to

--- a/src/capymoa/classifier/_passive_aggressive_classifier.py
+++ b/src/capymoa/classifier/_passive_aggressive_classifier.py
@@ -1,18 +1,22 @@
 from typing import Optional, Dict, Union, Literal
 from capymoa.base import SKClassifier
 from sklearn.linear_model import (
-    PassiveAggressiveClassifier as _SKPassiveAggressiveClassifier,
+    SGDClassifier as _SKSGDClassifier,
 )
 from capymoa.stream._stream import Schema
+
+# Maps the passive aggressive loss onto the equivalent scikit-learn learning
+# rate schedule: PA-I for the hinge loss and PA-II for the squared hinge loss.
+_LOSS_TO_LEARNING_RATE = {"hinge": "pa1", "squared_hinge": "pa2"}
 
 
 class PassiveAggressiveClassifier(SKClassifier):
     """Streaming Passive Aggressive Classifier.
 
     Streaming Passive Aggressive Classifier [#0]_ is a classifier. This wraps
-    :class:`~sklearn.linear_model.PassiveAggressiveClassifier` for ease of use in the streaming
-    context. Some options are missing because they are not relevant in the streaming
-    context.
+    :class:`~sklearn.linear_model.SGDClassifier` with a passive aggressive
+    learning rate schedule for ease of use in the streaming context. Some
+    options are missing because they are not relevant in the streaming context.
 
     >>> from capymoa.classifier import PassiveAggressiveClassifier
     >>> from capymoa.datasets import ElectricityTiny
@@ -29,15 +33,15 @@ class PassiveAggressiveClassifier(SKClassifier):
              <http://jmlr.csail.mit.edu/papers/volume7/crammer06a/crammer06a.pdf>`_
     """
 
-    sklearner: _SKPassiveAggressiveClassifier
-    """The underlying scikit-learn object. See: :sklearn:`linear_model.PassiveAggressiveClassifier`"""
+    sklearner: _SKSGDClassifier
+    """The underlying scikit-learn object. See: :sklearn:`linear_model.SGDClassifier`"""
 
     def __init__(
         self,
         schema: Schema,
         max_step_size: float = 1.0,
         fit_intercept: bool = True,
-        loss: str = "hinge",
+        loss: Literal["hinge", "squared_hinge"] = "hinge",
         n_jobs: Optional[int] = None,
         class_weight: Union[Dict[int, float], None, Literal["balanced"]] = None,
         average: bool = False,
@@ -68,16 +72,26 @@ class PassiveAggressiveClassifier(SKClassifier):
             seen reaches average. So ``average=10`` will begin averaging after
             seeing 10 samples.
         :param random_seed: Seed for the random number generator.
+        :raises ValueError: If ``loss`` is not one of the supported losses.
         """
 
+        if loss not in _LOSS_TO_LEARNING_RATE:
+            raise ValueError(
+                f"Unknown loss {loss!r}, expected one of "
+                f"{sorted(_LOSS_TO_LEARNING_RATE)}."
+            )
+
         super().__init__(
-            _SKPassiveAggressiveClassifier(
-                C=max_step_size,
+            _SKSGDClassifier(
+                loss="hinge",
+                penalty=None,
+                alpha=1.0,
+                learning_rate=_LOSS_TO_LEARNING_RATE[loss],
+                eta0=max_step_size,
                 fit_intercept=fit_intercept,
                 early_stopping=False,
                 shuffle=False,
                 verbose=0,
-                loss=loss,
                 n_jobs=n_jobs,
                 warm_start=False,
                 class_weight=class_weight,

--- a/src/capymoa/datasets/_utils.py
+++ b/src/capymoa/datasets/_utils.py
@@ -77,7 +77,11 @@ def download_unpacked(url: str, downloads: Path | str) -> Path:
             with open(path, "xb") as fdst:
                 copyfileobj(fin, fdst)
     elif format is not None:
-        unpack_archive(tmpfile, path, format=format)
+        # Python 3.14 makes ``filter="data"`` the default for tar archives and
+        # warns until then. Ask for it explicitly: it rejects members that would
+        # escape the destination directory. The zip unpacker takes no filter.
+        filter_kwargs = {} if format == "zip" else {"filter": "data"}
+        unpack_archive(tmpfile, path, format=format, **filter_kwargs)
     else:
         move(tmpfile, path)
     return path

--- a/src/capymoa/regressor/_passive_aggressive_regressor.py
+++ b/src/capymoa/regressor/_passive_aggressive_regressor.py
@@ -1,16 +1,25 @@
+from typing import Literal
 from capymoa.base import SKRegressor
 from sklearn.linear_model import (
-    PassiveAggressiveRegressor as _SKPassiveAggressiveRegressor,
+    SGDRegressor as _SKSGDRegressor,
 )
 from capymoa.stream._stream import Schema
+
+# Maps the passive aggressive loss onto the equivalent scikit-learn learning
+# rate schedule: PA-I for the epsilon insensitive loss and PA-II for its
+# squared variant.
+_LOSS_TO_LEARNING_RATE = {
+    "epsilon_insensitive": "pa1",
+    "squared_epsilon_insensitive": "pa2",
+}
 
 
 class PassiveAggressiveRegressor(SKRegressor):
     """Streaming Passive Aggressive regressor
 
-    This wraps :sklearn:`linear_model.PassiveAggressiveRegressor` for
-    ease of use in the streaming context. Some options are missing because
-    they are not relevant in the streaming context.
+    This wraps :sklearn:`linear_model.SGDRegressor` with a passive aggressive
+    learning rate schedule for ease of use in the streaming context. Some
+    options are missing because they are not relevant in the streaming context.
 
     Reference:
 
@@ -31,15 +40,17 @@ class PassiveAggressiveRegressor(SKRegressor):
     3.700...
     """
 
-    sklearner: _SKPassiveAggressiveRegressor
-    """The underlying scikit-learn object. See: :sklearn:`linear_model.PassiveAggressiveRegressor`"""
+    sklearner: _SKSGDRegressor
+    """The underlying scikit-learn object. See: :sklearn:`linear_model.SGDRegressor`"""
 
     def __init__(
         self,
         schema: Schema,
         max_step_size: float = 1.0,
         fit_intercept: bool = True,
-        loss: str = "epsilon_insensitive",
+        loss: Literal[
+            "epsilon_insensitive", "squared_epsilon_insensitive"
+        ] = "epsilon_insensitive",
         average: bool = False,
         random_seed=1,
     ):
@@ -61,16 +72,26 @@ class PassiveAggressiveRegressor(SKRegressor):
             seen reaches average. So ``average=10`` will begin averaging after
             seeing 10 samples.
         :param random_seed: Seed for the random number generator.
+        :raises ValueError: If ``loss`` is not one of the supported losses.
         """
 
+        if loss not in _LOSS_TO_LEARNING_RATE:
+            raise ValueError(
+                f"Unknown loss {loss!r}, expected one of "
+                f"{sorted(_LOSS_TO_LEARNING_RATE)}."
+            )
+
         super().__init__(
-            _SKPassiveAggressiveRegressor(
-                C=max_step_size,
+            _SKSGDRegressor(
+                loss="epsilon_insensitive",
+                penalty=None,
+                alpha=1.0,
+                learning_rate=_LOSS_TO_LEARNING_RATE[loss],
+                eta0=max_step_size,
                 fit_intercept=fit_intercept,
                 early_stopping=False,
                 shuffle=False,
                 verbose=0,
-                loss=loss,
                 warm_start=False,
                 average=average,
                 random_state=random_seed,


### PR DESCRIPTION
Fixes adaptive-machine-learning/backlog#137:
```
FutureWarning: Class PassiveAggressiveClassifier is deprecated; this is deprecated in
version 1.8 and will be removed in 1.10.
```

Had to bump the python version 3.10 to 3.11 to use a newer version of sklearn to have the same features. This is a good idea because python 3.0 is end of life 2026.

Assisted-by: claude-code:claude-opus-5