### PR TITLE
fix(evaldriftdetector): count detections after last drift window as false positives

### DIFF
--- a/src/capymoa/drift/eval_detector.py
+++ b/src/capymoa/drift/eval_detector.py
@@ -213,6 +213,7 @@ class EvaluateDriftDetector:
                     UserWarning,
                 )
             drift_eps = drift_episodes
+            trailing_fp_count = 0
         else:
             if trues is None or preds is None:
                 raise ValueError(
@@ -221,6 +222,13 @@ class EvaluateDriftDetector:
 
             self._check_arrays(trues, preds)
             drift_eps = self._get_drift_episodes(trues=trues, preds=preds)
+
+            trues_array = np.asarray(trues)
+            if trues_array.ndim == 1:
+                trues_array = np.column_stack((trues_array, trues_array))
+            last_episode_end = int(trues_array[-1, 1]) + self.max_delay
+            preds_array = np.asarray(preds)
+            trailing_fp_count = int(np.sum(preds_array > last_episode_end))
 
         fp, tp, fn = 0, 0, 0
         etp = 0  # episode true positives
@@ -263,6 +271,9 @@ class EvaluateDriftDetector:
                 detection_times.append(episode_detection_time)
             else:
                 fn += 1
+
+        fp += trailing_fp_count
+        n_alarms += trailing_fp_count
 
         precision, recall, f1 = self._calc_classification_metrics(tp=tp, fp=fp, fn=fn)
         false_alarm_rate = (fp / max(1, tot_n_instances)) * self.rate_period

--- a/tests/test_eval_detector.py
+++ b/tests/test_eval_detector.py
@@ -4,6 +4,22 @@ import pytest
 from capymoa.drift.eval_detector import EvaluateDriftDetector
 
 
+def test_trailing_predictions_after_last_drift_window_are_false_positives():
+    metrics = EvaluateDriftDetector(max_delay=50).calc_performance(
+        trues=np.asarray([(5000, 5000)], dtype=int),
+        preds=np.asarray([576, 5024, 5216, 5696, 6848], dtype=int),
+        tot_n_instances=10_000,
+    )
+
+    assert metrics.tp == 1
+    assert metrics.fp == 4
+    assert metrics.n_alarms == 5
+    assert metrics.precision == pytest.approx(0.2)
+    assert metrics.f1 == pytest.approx(1 / 3)
+    assert metrics.far == pytest.approx(0.4)
+    assert metrics.ar == pytest.approx(0.5)
+
+
 def test_ndt_is_mdt_over_max_delay():
     """``ndt`` restates ``mdt`` as a fraction of the acceptable delay."""
     metrics = EvaluateDriftDetector(max_delay=200).calc_performance(


### PR DESCRIPTION
Problem: Predictions occurring after the last drift episode's window (drift_end + max_delay) were silently dropped by _get_drift_episodes, so they were never counted as false positives.

Fix: In calc_performance, after building the drift episodes from trues/preds, I compute how many predictions fall beyond the last episode boundary and add them to fp and n_alarms before calculating the final metrics.