### PR TITLE
feat(evaluation): add ROC AUC metric

### DIFF
--- a/invoke.yml
+++ b/invoke.yml
@@ -5,7 +5,7 @@ moa_path: "src/capymoa/jar/moa.jar"
 # DROPBOX: When using a dropbox link, ensure that the dl=1 query parameter is 
 # present in the link. This ensures  the file is downloaded directly instead
 # of going to the dropbox page
-moa_url: "https://www.dropbox.com/scl/fi/fegpeb8o7342zceyz96ht/260416_moa.jar?rlkey=dv6g6pzlj67zmhw8xfqs4g00m&st=5inm3eiq&dl=1"
+moa_url: "https://www.dropbox.com/scl/fi/mlafxwhhym97rrdy7y6ur/260907_moa.jar?rlkey=57nzpynr6l21gm6w111msbu8x&st=ob0ipe5m&dl=1"
 
 # What notebooks to skip when running them as tests.
 # YOU SHOULD NOT SKIP NOTEBOOKS!

--- a/src/capymoa/_utils.py
+++ b/src/capymoa/_utils.py
@@ -20,6 +20,7 @@ _metrics_name_mapping = {
     "precision_{N}": "Precision for class {N} (percent)",
     "recall": "Recall (percent)",
     "recall_{N}": "Recall for class {N} (percent)",
+    "roc_auc": "ROC AUC (cumulative)",
     # regression
     "mae": "mean absolute error",
     "rmse": "root mean squared error",

--- a/src/capymoa/evaluation/evaluation.py
+++ b/src/capymoa/evaluation/evaluation.py
@@ -114,6 +114,7 @@ class ClassificationEvaluator:
         self.moa_basic_evaluator.precisionPerClassOption.set()
         self.moa_basic_evaluator.precisionRecallOutputOption.set()
         self.moa_basic_evaluator.f1PerClassOption.set()
+        self.moa_basic_evaluator.rocAucOption.set()
         self.moa_basic_evaluator.prepareForUse()
 
         _attributeValues = ArrayList()
@@ -284,6 +285,10 @@ class ClassificationEvaluator:
 
     def recall(self):
         index = self.metrics_header().index("recall")
+        return float(self.metrics()[index])
+
+    def roc_auc(self):
+        index = self.metrics_header().index("roc_auc")
         return float(self.metrics()[index])
 
 
@@ -744,6 +749,9 @@ class ClassificationWindowedEvaluator(ClassificationEvaluator):
 
     def recall(self):
         return self.metrics_per_window()["recall"].tolist()
+
+    def roc_auc(self):
+        return self.metrics_per_window()["roc_auc"].tolist()
 
 
 class RegressionWindowedEvaluator(RegressionEvaluator):

--- a/tests/test_moajar.py
+++ b/tests/test_moajar.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from hashlib import sha256
 import capymoa
 
-_MOA_JAR_HASH = "e2e5661d361c7e42912be4546168b10e858e85e64a75bc8627d5a5493ec30e63"
+_MOA_JAR_HASH = "e7d7c3d533a4800bf2581f820d2c1e9310d70ff40b52fc1a742793eceb89a660"
 
 
 def test_imports() -> None:


### PR DESCRIPTION
## Summary
- Bump the bundled MOA jar (invoke.yml) to the version that adds a prequential ROC AUC to `BasicClassificationPerformanceEvaluator` (Waikato/moa#332).
- Enable the new `rocAUC` option by default in `ClassificationEvaluator`, and expose it as `roc_auc()` on both `ClassificationEvaluator` and `ClassificationWindowedEvaluator`, so it's accessible from `PrequentialResults` the same way as `accuracy`, `kappa`, `f1_score`, etc.
- Add the `roc_auc` -> `"ROC AUC (cumulative)"` name mapping used to translate between CapyMOA and MOA metric names.

Note: MOA computes ROC AUC prequentially for binary classification only, reporting `NaN` for multi-class problems (see adaptive-machine-learning/backlog#23, which had been blocked on an alternative approach — we ended up simply adding ROC AUC to the evaluator instead).

## Test plan
- [x] `pytest tests/test_evaluation.py` passes (47 passed), including `test_evaluation_api` which generically checks every metric returned by `metrics_header()` is accessible through `PrequentialResults`.
- [x] Manually verified `results.cumulative.roc_auc()`, `results.roc_auc()` (delegated), and `results.windowed.roc_auc()` all return sensible values on `ElectricityTiny` with `HoeffdingTree`.

Assisted-by: claude-code:claude-sonnet-5