### PR TITLE
feat(classifier): add StochasticGradientTree wrapper

### DIFF
--- a/src/capymoa/classifier/__init__.py
+++ b/src/capymoa/classifier/__init__.py
@@ -35,6 +35,7 @@ from ._plastic import PLASTIC
 from ._samknn import SAMkNN
 from ._sgbt import StreamingGradientBoostedTrees
 from ._sgd_classifier import SGDClassifier
+from ._sgt import StochasticGradientTree
 from ._shrubs_classifier import ShrubsClassifier
 from ._srp import StreamingRandomPatches
 from ._weightedknn import WeightedkNN
@@ -63,6 +64,7 @@ __all__ = [
     "SAMkNN",
     "SGDClassifier",
     "ShrubsClassifier",
+    "StochasticGradientTree",
     "StreamingGradientBoostedTrees",
     "StreamingRandomPatches",
     "WeightedkNN",

--- a/src/capymoa/classifier/_sgt.py
+++ b/src/capymoa/classifier/_sgt.py
@@ -1,0 +1,81 @@
+from typing import Literal
+
+from moa.classifiers.trees import StochasticGradientTree as _StochasticGradientTree
+
+from capymoa.base import MOAClassifier
+from capymoa.core.moa._cli import cli_str_classifier
+from capymoa.stream import Schema
+
+
+class StochasticGradientTree(MOAClassifier):
+    """Stochastic Gradient Tree classifier.
+
+    Stochastic Gradient Tree (SGT) [#f1]_ is an incremental decision tree that learns
+    using stochastic gradient information as its source of supervision, rather than
+    a heuristic such as information gain. Instead of using soft splits or rebuilding
+    a new tree for every update, as prior gradient-based tree learners did in the
+    batch setting, SGT accumulates per-node gradient and Hessian statistics online
+    and uses them to make hard splitting decisions incrementally. Because splitting
+    is driven only by the loss function's gradients and Hessians, the same algorithm
+    can be applied to classification, regression, or multi-instance learning simply
+    by changing the loss function.
+
+    >>> from capymoa.classifier import StochasticGradientTree
+    >>> from capymoa.datasets import ElectricityTiny
+    >>> from capymoa.evaluation import prequential_evaluation
+    >>>
+    >>> stream = ElectricityTiny()
+    >>> classifier = StochasticGradientTree(stream.get_schema())
+    >>> results = prequential_evaluation(stream, classifier, max_instances=1000)
+    >>> print(f"{results['cumulative'].accuracy():.1f}")
+    50.6
+
+    .. [#f1] Gouk, Henry, Bernhard Pfahringer, and Eibe Frank. "Stochastic Gradient
+             Trees." Proceedings of The 11th Asian Conference on Machine Learning
+             (ACML 2019). PMLR 101, 2019, pp. 1094-1109.
+    """
+
+    def __init__(
+        self,
+        schema: Schema,
+        discretizer: str | MOAClassifier = (
+            "StochasticGradientTree$EqualWidthDiscretizer"
+        ),
+        grace_period: int = 200,
+        lambda_: float = 0.1,
+        warm_start: int = 1000,
+        confidence: float = 1e-06,
+        split_test: Literal["TTest"] = "TTest",
+        disable_resplits: bool = False,
+    ) -> None:
+        """Construct StochasticGradientTree classifier.
+
+        :param discretizer: Discretizer to use for numeric attributes.
+        :param grace_period: The number of instances a leaf should observe between
+            split attempts.
+        :param lambda_: Regularization parameter lambda.
+        :param warm_start: Number of instances to use for fitting the discretizers.
+        :param confidence: The level of confidence required that a split candidate is
+            an improvement before the split is actually performed.
+        :param split_test: Which type of hypothesis test to use for determining when
+            to split.
+
+            * ``TTest``: Use a t-Test for checking statistical significance.
+        :param disable_resplits: Disable node resplitting.
+        """
+
+        if isinstance(discretizer, MOAClassifier):
+            discretizer = cli_str_classifier(discretizer)
+
+        cli = []
+        cli += [f"-D ({discretizer})"]
+        cli += [f"-G {grace_period}"]
+        cli += [f"-L {lambda_}"]
+        cli += [f"-W {warm_start}"]
+        cli += [f"-C {confidence}"]
+        cli += [f"-T '{split_test}'"]
+        cli += ["-R"] if disable_resplits else []
+
+        super().__init__(
+            moa_learner=_StochasticGradientTree, schema=schema, CLI=" ".join(cli)
+        )

--- a/src/capymoa/regressor/__init__.py
+++ b/src/capymoa/regressor/__init__.py
@@ -15,6 +15,7 @@ from ._orto import ORTO
 from ._passive_aggressive_regressor import PassiveAggressiveRegressor
 from ._sgbr import StreamingGradientBoostedRegression
 from ._sgd_regressor import SGDRegressor
+from ._sgt import StochasticGradientTree
 from ._shrubs_regressor import ShrubsRegressor
 from ._soknl import SOKNL
 from ._soknl_base_tree import SOKNLBT
@@ -33,6 +34,7 @@ __all__ = [
     "PassiveAggressiveRegressor",
     "SGDRegressor",
     "ShrubsRegressor",
+    "StochasticGradientTree",
     "StreamingGradientBoostedRegression",
     "TargetMean",
 ]

--- a/src/capymoa/regressor/_sgt.py
+++ b/src/capymoa/regressor/_sgt.py
@@ -2,12 +2,12 @@ from typing import Literal
 
 from moa.classifiers.trees import StochasticGradientTree as _StochasticGradientTree
 
-from capymoa.base import MOAClassifier
+from capymoa.base import MOARegressor
 from capymoa.stream import Schema
 
 
-class StochasticGradientTree(MOAClassifier):
-    """Stochastic Gradient Tree classifier.
+class StochasticGradientTree(MOARegressor):
+    """Stochastic Gradient Tree regressor.
 
     Stochastic Gradient Tree (SGT) [#f1]_ is an incremental decision tree that learns
     using stochastic gradient information as its source of supervision, rather than
@@ -19,15 +19,15 @@ class StochasticGradientTree(MOAClassifier):
     can be applied to classification, regression, or multi-instance learning simply
     by changing the loss function.
 
-    >>> from capymoa.classifier import StochasticGradientTree
-    >>> from capymoa.datasets import ElectricityTiny
+    >>> from capymoa.regressor import StochasticGradientTree
+    >>> from capymoa.datasets import Fried
     >>> from capymoa.evaluation import prequential_evaluation
     >>>
-    >>> stream = ElectricityTiny()
-    >>> classifier = StochasticGradientTree(stream.get_schema())
-    >>> results = prequential_evaluation(stream, classifier, max_instances=1000)
-    >>> print(f"{results['cumulative'].accuracy():.1f}")
-    50.6
+    >>> stream = Fried()
+    >>> learner = StochasticGradientTree(stream.get_schema())
+    >>> results = prequential_evaluation(stream, learner, max_instances=1000)
+    >>> round(results["cumulative"].rmse(), 2)
+    15.49
 
     .. [#f1] Gouk, Henry, Bernhard Pfahringer, and Eibe Frank. "Stochastic Gradient
              Trees." Proceedings of The 11th Asian Conference on Machine Learning
@@ -44,7 +44,7 @@ class StochasticGradientTree(MOAClassifier):
         split_test: Literal["TTest"] = "TTest",
         disable_resplits: bool = False,
     ) -> None:
-        """Construct StochasticGradientTree classifier.
+        """Construct StochasticGradientTree regressor.
 
         :param grace_period: The number of instances a leaf should observe between
             split attempts.
@@ -68,5 +68,5 @@ class StochasticGradientTree(MOAClassifier):
         cli += ["-R"] if disable_resplits else []
 
         super().__init__(
-            moa_learner=_StochasticGradientTree, schema=schema, CLI=" ".join(cli)
+            moa_learner=_StochasticGradientTree(), schema=schema, CLI=" ".join(cli)
         )

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -34,6 +34,7 @@ from capymoa.classifier import (
     SAMkNN,
     SGDClassifier,
     ShrubsClassifier,
+    StochasticGradientTree,
     StreamingGradientBoostedTrees,
     StreamingRandomPatches,
     WeightedkNN,
@@ -141,6 +142,12 @@ test_cases = [
         skip_reason="https://github.com/adaptive-machine-learning/backlog/issues/59",
     ),
     ClassifierTestCase("PLASTIC", PLASTIC, 83.25, 83.0),
+    ClassifierTestCase(
+        "StochasticGradientTree",
+        partial(StochasticGradientTree),
+        63.35,
+        80.0,
+    ),
     ClassifierTestCase(
         "NaiveBayes",
         partial(NaiveBayes),

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -23,6 +23,7 @@ from capymoa.regressor import (
     PassiveAggressiveRegressor,
     SGDRegressor,
     ShrubsRegressor,
+    StochasticGradientTree,
     StreamingGradientBoostedRegression,
     TargetMean,
 )
@@ -64,6 +65,7 @@ CASES = [
     Case(PassiveAggressiveRegressor, 3.70, 3.68),
     Case(SGDRegressor, 4.63, 3.61),
     Case(ShrubsRegressor, 5.21, 4.76),
+    Case(StochasticGradientTree, 15.49, 16.19),
     Case(StreamingGradientBoostedRegression, 3.09, 2.21),
 ]
 """Add your new test cases here ^^"""


### PR DESCRIPTION
## Summary
- Adds `StochasticGradientTree` (SGT) classifier wrapping `moa.classifiers.trees.StochasticGradientTree`, generated with `tools/template`
- Registers it in `capymoa.classifier.__all__`
- Adds a parameterised test case in `tests/test_classifiers.py`

Closes #222

## Test plan
- [x] `pytest --doctest-modules src/capymoa/classifier/_sgt.py`
- [x] `pytest tests/test_classifiers.py -k StochasticGradientTree`
- [x] `ruff format --check` / `ruff check` on changed files

Assisted-by: claude-code:claude-sonnet-5